### PR TITLE
chore: Compatibility with Nextcloud 34

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -11,7 +11,7 @@
             "dependencies": {
                 "@nextcloud/auth": "^2.5.1",
                 "@nextcloud/event-bus": "^3.3.1",
-                "@nextcloud/files": "^3.0.0",
+                "@nextcloud/files": "^4.0.0",
                 "@nextcloud/initial-state": "^2.2.0",
                 "@nextcloud/l10n": "^3.4.1",
                 "@nextcloud/router": "^3.1.0",
@@ -1010,10 +1010,32 @@
             }
         },
         "node_modules/@nextcloud/files": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@nextcloud/files/-/files-4.0.0.tgz",
+            "integrity": "sha512-TmecnZIS+PGWGtRh7RpGEboCT4K6iTbHULUcfR6hs3eEzjDVsCc1Ldf8popGY/70lbpdlfYle8xbXnPIo3qaXA==",
+            "license": "AGPL-3.0-or-later",
+            "dependencies": {
+                "@nextcloud/auth": "^2.5.3",
+                "@nextcloud/capabilities": "^1.2.1",
+                "@nextcloud/l10n": "^3.4.1",
+                "@nextcloud/logger": "^3.0.3",
+                "@nextcloud/paths": "^3.0.0",
+                "@nextcloud/router": "^3.1.0",
+                "@nextcloud/sharing": "^0.3.0",
+                "is-svg": "^6.1.0",
+                "typescript-event-target": "^1.1.2",
+                "webdav": "^5.9.0"
+            },
+            "engines": {
+                "node": "^24.0.0"
+            }
+        },
+        "node_modules/@nextcloud/files/node_modules/@nextcloud/files": {
             "version": "3.12.2",
             "resolved": "https://registry.npmjs.org/@nextcloud/files/-/files-3.12.2.tgz",
             "integrity": "sha512-vBo8tf3Xh6efiF8CrEo3pKj9AtvAF6RdDGO1XKL65IxV8+UUd9Uxl2lUExHlzoDRRczCqfGfaWfRRaFhYqce5Q==",
             "license": "AGPL-3.0-or-later",
+            "optional": true,
             "dependencies": {
                 "@nextcloud/auth": "^2.5.3",
                 "@nextcloud/capabilities": "^1.2.1",
@@ -1222,6 +1244,29 @@
             },
             "peerDependencies": {
                 "vue": "2.x"
+            }
+        },
+        "node_modules/@nextcloud/vue/node_modules/@nextcloud/files": {
+            "version": "3.12.2",
+            "resolved": "https://registry.npmjs.org/@nextcloud/files/-/files-3.12.2.tgz",
+            "integrity": "sha512-vBo8tf3Xh6efiF8CrEo3pKj9AtvAF6RdDGO1XKL65IxV8+UUd9Uxl2lUExHlzoDRRczCqfGfaWfRRaFhYqce5Q==",
+            "license": "AGPL-3.0-or-later",
+            "optional": true,
+            "dependencies": {
+                "@nextcloud/auth": "^2.5.3",
+                "@nextcloud/capabilities": "^1.2.1",
+                "@nextcloud/l10n": "^3.4.1",
+                "@nextcloud/logger": "^3.0.3",
+                "@nextcloud/paths": "^3.0.0",
+                "@nextcloud/router": "^3.1.0",
+                "@nextcloud/sharing": "^0.3.0",
+                "cancelable-promise": "^4.3.1",
+                "is-svg": "^6.1.0",
+                "typescript-event-target": "^1.1.1",
+                "webdav": "^5.8.0"
+            },
+            "engines": {
+                "node": "^20.0.0 || ^22.0.0 || ^24.0.0"
             }
         },
         "node_modules/@nextcloud/vue/node_modules/@nextcloud/sharing": {
@@ -3195,7 +3240,9 @@
         "node_modules/cancelable-promise": {
             "version": "4.3.1",
             "resolved": "https://registry.npmjs.org/cancelable-promise/-/cancelable-promise-4.3.1.tgz",
-            "integrity": "sha512-A/8PwLk/T7IJDfUdQ68NR24QHa8rIlnN/stiJEBo6dmVUkD4K14LswG0w3VwdeK/o7qOwRUR1k2MhK5Rpy2m7A=="
+            "integrity": "sha512-A/8PwLk/T7IJDfUdQ68NR24QHa8rIlnN/stiJEBo6dmVUkD4K14LswG0w3VwdeK/o7qOwRUR1k2MhK5Rpy2m7A==",
+            "license": "MIT",
+            "optional": true
         },
         "node_modules/caniuse-lite": {
             "version": "1.0.30001717",
@@ -5589,12 +5636,14 @@
             "version": "4.5.3",
             "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.5.3.tgz",
             "integrity": "sha512-RKihhV+SHsIUGXObeVy9AXiBbFwkVk7Syp8XgwN5U3JV416+Gwp/GO9i0JYKmikykgz/UHRrrV4ROuZEo/T0ig==",
+            "dev": true,
             "funding": [
                 {
                     "type": "github",
                     "url": "https://github.com/sponsors/NaturalIntelligence"
                 }
             ],
+            "peer": true,
             "dependencies": {
                 "strnum": "^1.1.1"
             },
@@ -10992,12 +11041,14 @@
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.1.2.tgz",
             "integrity": "sha512-vrN+B7DBIoTTZjnPNewwhx6cBA/H+IS7rfW68n7XxC1y7uoiGQBxaKzqucGUgavX15dJgiGztLJ8vxuEzwqBdA==",
+            "dev": true,
             "funding": [
                 {
                     "type": "github",
                     "url": "https://github.com/sponsors/NaturalIntelligence"
                 }
-            ]
+            ],
+            "peer": true
         },
         "node_modules/strtok3": {
             "version": "10.3.4",
@@ -12485,16 +12536,16 @@
             }
         },
         "node_modules/webdav": {
-            "version": "5.8.0",
-            "resolved": "https://registry.npmjs.org/webdav/-/webdav-5.8.0.tgz",
-            "integrity": "sha512-iuFG7NamJ41Oshg4930iQgfIpRrUiatPWIekeznYgEf2EOraTRcDPTjy7gIOMtkdpKTaqPk1E68NO5PAGtJahA==",
+            "version": "5.9.0",
+            "resolved": "https://registry.npmjs.org/webdav/-/webdav-5.9.0.tgz",
+            "integrity": "sha512-OMJ6wtK1WvCO++aOLoQgE96S8KT4e5aaClWHmHXfFU369r4eyELN569B7EqT4OOUb99mmO58GkyuiCv/Ag6J0Q==",
             "license": "MIT",
             "dependencies": {
                 "@buttercup/fetch": "^0.2.1",
                 "base-64": "^1.0.0",
                 "byte-length": "^1.0.2",
-                "entities": "^6.0.0",
-                "fast-xml-parser": "^4.5.1",
+                "entities": "^6.0.1",
+                "fast-xml-parser": "^5.3.4",
                 "hot-patcher": "^2.0.1",
                 "layerr": "^3.0.0",
                 "md5": "^2.3.0",
@@ -12520,6 +12571,36 @@
             "funding": {
                 "url": "https://github.com/fb55/entities?sponsor=1"
             }
+        },
+        "node_modules/webdav/node_modules/fast-xml-parser": {
+            "version": "5.3.6",
+            "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.3.6.tgz",
+            "integrity": "sha512-QNI3sAvSvaOiaMl8FYU4trnEzCwiRr8XMWgAHzlrWpTSj+QaCSvOf1h82OEP1s4hiAXhnbXSyFWCf4ldZzZRVA==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/NaturalIntelligence"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "strnum": "^2.1.2"
+            },
+            "bin": {
+                "fxparser": "src/cli/cli.js"
+            }
+        },
+        "node_modules/webdav/node_modules/strnum": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.1.2.tgz",
+            "integrity": "sha512-l63NF9y/cLROq/yqKXSLtcMeeyOfnSQlfMSlzFt/K73oIaD8DGaQWd7Z34X9GPiKqP5rbSh84Hl4bOlLcjiSrQ==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/NaturalIntelligence"
+                }
+            ],
+            "license": "MIT"
         },
         "node_modules/webpack": {
             "version": "5.99.7",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     },
     "dependencies": {
         "@nextcloud/auth": "^2.5.1",
+        "@nextcloud/axios": "^2.4.0",
         "@nextcloud/event-bus": "^3.3.1",
         "@nextcloud/files": "^4.0.0",
         "@nextcloud/initial-state": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "dependencies": {
         "@nextcloud/auth": "^2.5.1",
         "@nextcloud/event-bus": "^3.3.1",
-        "@nextcloud/files": "^3.0.0",
+        "@nextcloud/files": "^4.0.0",
         "@nextcloud/initial-state": "^2.2.0",
         "@nextcloud/l10n": "^3.4.1",
         "@nextcloud/router": "^3.1.0",

--- a/src/desktop.js
+++ b/src/desktop.js
@@ -26,7 +26,7 @@
  *
  */
 
-/* global $, _, _oc_appswebroots, oc_current_user  */
+/* global _, _oc_appswebroots, oc_current_user  */
 
 /**
  * @param {object} OCA Nextcloud OCA object
@@ -46,7 +46,7 @@
 		return
 	}
 
-	$('html').addClass('AscDesktopEditor')
+	document.documentElement.classList.add('AscDesktopEditor')
 
 	let domain = /^http(s)?:\/\/[^\\/]+/.exec(location)[0]
 	domain += OC.getRootPath()

--- a/src/editor.js
+++ b/src/editor.js
@@ -26,13 +26,14 @@
  *
  */
 
-/* global _, DocsAPI, jQuery, moment, oc_defaults */
+/* global _, DocsAPI, moment, oc_defaults */
+
+import axios from '@nextcloud/axios'
 
 /**
- * @param {object} $ JQueryStatic object
  * @param {object} OCA Nextcloud OCA object
  */
-(function($, OCA) {
+(function(OCA) {
 
 	OCA.Onlyoffice = _.extend({
 		AppName: 'onlyoffice',
@@ -45,14 +46,19 @@
 
 	OCA.Onlyoffice.InitEditor = function() {
 
-		OCA.Onlyoffice.fileId = $('#iframeEditor').data('id')
-		OCA.Onlyoffice.shareToken = $('#iframeEditor').data('sharetoken')
-		OCA.Onlyoffice.directToken = $('#iframeEditor').data('directtoken')
-		OCA.Onlyoffice.template = $('#iframeEditor').data('template')
-		OCA.Onlyoffice.inframe = !!$('#iframeEditor').data('inframe')
-		OCA.Onlyoffice.inviewer = !!$('#iframeEditor').data('inviewer')
-		OCA.Onlyoffice.filePath = $('#iframeEditor').data('path')
-		OCA.Onlyoffice.anchor = $('#iframeEditor').attr('data-anchor')
+		const iframeEditor = document.getElementById('iframeEditor')
+		if (!iframeEditor) {
+			return
+		}
+
+		OCA.Onlyoffice.fileId = iframeEditor.dataset.id
+		OCA.Onlyoffice.shareToken = iframeEditor.dataset.sharetoken
+		OCA.Onlyoffice.directToken = iframeEditor.dataset.directtoken
+		OCA.Onlyoffice.template = iframeEditor.dataset.template
+		OCA.Onlyoffice.inframe = !!iframeEditor.dataset.inframe
+		OCA.Onlyoffice.inviewer = !!iframeEditor.dataset.inviewer
+		OCA.Onlyoffice.filePath = iframeEditor.dataset.path
+		OCA.Onlyoffice.anchor = iframeEditor.getAttribute('data-anchor')
 		OCA.Onlyoffice.currentWindow = window
 		OCA.Onlyoffice.currentUser = OC.getCurrentUser()
 
@@ -68,9 +74,9 @@
 
 		const configUrl = OCA.Onlyoffice.getConfigUrl()
 
-		$.ajax({
-			url: configUrl,
-			success: function onSuccess(config) {
+		axios.get(configUrl)
+			.then((response) => {
+				const config = response.data
 				if (config) {
 					OCA.Onlyoffice.device = config.type
 					if (OCA.Onlyoffice.device === 'mobile') {
@@ -193,8 +199,11 @@
 						}
 
 						if (!OCA.Onlyoffice.directEditor
-							&& config.type === 'mobile' && $('#app > iframe').css('position') === 'fixed') {
-							$('#app > iframe').css('height', 'calc(100% - 50px)')
+						&& config.type === 'mobile') {
+						const appIframe = document.querySelector('#app > iframe')
+						if (appIframe && window.getComputedStyle(appIframe).position === 'fixed') {
+							appIframe.style.height = 'calc(100% - 50px)'
+						}
 						}
 
 						const favicon = OC.filePath(OCA.Onlyoffice.AppName, 'img', OCA.Onlyoffice.documentType + '.ico')
@@ -205,56 +214,60 @@
 							},
 							'*')
 						} else {
-							$('link[rel="icon"]').attr('href', favicon)
+							const faviconLink = document.querySelector('link[rel="icon"]')
+							if (faviconLink) {
+								faviconLink.setAttribute('href', favicon)
+							}
 						}
 					}
 					document.head.appendChild(script)
 				}
-			},
-		})
+			})
+			.catch((error) => {
+				OCA.Onlyoffice.showMessage(error.message || t(OCA.Onlyoffice.AppName, 'Failed to load configuration'), 'error', { timeout: -1 })
+			})
 	}
 
 	OCA.Onlyoffice.onRequestHistory = function(version) {
-		$.get(OC.generateUrl('apps/' + OCA.Onlyoffice.AppName + '/ajax/history?fileId={fileId}',
+		axios.get(OC.generateUrl('apps/' + OCA.Onlyoffice.AppName + '/ajax/history?fileId={fileId}',
 			{
 				fileId: OCA.Onlyoffice.fileId || 0,
-			}),
-		function onSuccess(response) {
-			OCA.Onlyoffice.refreshHistory(response, version)
-		})
+			}))
+			.then((response) => {
+				OCA.Onlyoffice.refreshHistory(response.data, version)
+			})
 	}
 
 	OCA.Onlyoffice.onRequestHistoryData = function(event) {
 		const version = event.data
 
-		$.get(OC.generateUrl('apps/' + OCA.Onlyoffice.AppName + '/ajax/version?fileId={fileId}&version={version}',
+		axios.get(OC.generateUrl('apps/' + OCA.Onlyoffice.AppName + '/ajax/version?fileId={fileId}&version={version}',
 			{
 				fileId: OCA.Onlyoffice.fileId || 0,
 				version,
-			}),
-		function onSuccess(response) {
-			if (response.error) {
-				response = {
-					error: response.error,
-					version,
+			}))
+			.then((response) => {
+				let data = response.data
+				if (data.error) {
+					data = {
+						error: data.error,
+						version,
+					}
 				}
-			}
-			OCA.Onlyoffice.docEditor.setHistoryData(response)
-		})
+				OCA.Onlyoffice.docEditor.setHistoryData(data)
+			})
 	}
 
 	OCA.Onlyoffice.onRequestRestore = function(event) {
 		const version = event.data.version
 
-		$.ajax({
-			method: 'PUT',
-			url: OC.generateUrl('apps/' + OCA.Onlyoffice.AppName + '/ajax/restore'),
-			data: {
-				fileId: OCA.Onlyoffice.fileId || 0,
-				version,
-			},
-			success: function onSuccess(response) {
-				OCA.Onlyoffice.refreshHistory(response, response.at(-1).version)
+		axios.put(OC.generateUrl('apps/' + OCA.Onlyoffice.AppName + '/ajax/restore'), {
+			fileId: OCA.Onlyoffice.fileId || 0,
+			version,
+		})
+			.then((response) => {
+				const data = response.data
+				OCA.Onlyoffice.refreshHistory(data, data.at(-1).version)
 
 				if (OCA.Onlyoffice.inframe) {
 					window.parent.postMessage({
@@ -262,11 +275,7 @@
 					},
 					'*')
 				}
-			},
-		})
-	}
-
-	OCA.Onlyoffice.onRequestHistoryClose = function() {
+			})
 		location.reload(true)
 	}
 
@@ -317,15 +326,15 @@
 	}
 
 	OCA.Onlyoffice.editorSaveAs = function(saveData) {
-		$.post(OC.generateUrl('apps/' + OCA.Onlyoffice.AppName + '/ajax/save'),
-			saveData,
-			function onSuccess(response) {
-				if (response.error) {
-					OCA.Onlyoffice.showMessage(response.error, 'error')
+		axios.post(OC.generateUrl('apps/' + OCA.Onlyoffice.AppName + '/ajax/save'), saveData)
+			.then((response) => {
+				const data = response.data
+				if (data.error) {
+					OCA.Onlyoffice.showMessage(data.error, 'error')
 					return
 				}
 
-				OCA.Onlyoffice.showMessage(t(OCA.Onlyoffice.AppName, 'File saved') + ' (' + response.name + ')')
+				OCA.Onlyoffice.showMessage(t(OCA.Onlyoffice.AppName, 'File saved') + ' (' + data.name + ')')
 			})
 	}
 
@@ -358,22 +367,23 @@
 	}
 
 	OCA.Onlyoffice.editorInsertImage = function(filePath) {
-		$.get(OC.generateUrl('apps/' + OCA.Onlyoffice.AppName + '/ajax/url?filePath={filePath}',
+		axios.get(OC.generateUrl('apps/' + OCA.Onlyoffice.AppName + '/ajax/url?filePath={filePath}',
 			{
 				filePath,
-			}),
-		function onSuccess(response) {
-			if (response.error) {
-				OCA.Onlyoffice.showMessage(response.error, 'error')
-				return
-			}
+			}))
+			.then((response) => {
+				const data = response.data
+				if (data.error) {
+					OCA.Onlyoffice.showMessage(data.error, 'error')
+					return
+				}
 
-			if (OCA.Onlyoffice.insertImageType) {
-				response.c = OCA.Onlyoffice.insertImageType
-			}
+				if (OCA.Onlyoffice.insertImageType) {
+					data.c = OCA.Onlyoffice.insertImageType
+				}
 
-			OCA.Onlyoffice.docEditor.insertImage(response)
-		})
+				OCA.Onlyoffice.docEditor.insertImage(data)
+			})
 	}
 
 	OCA.Onlyoffice.onRequestMailMergeRecipients = function() {
@@ -397,18 +407,19 @@
 	}
 
 	OCA.Onlyoffice.editorSetRecipient = function(filePath) {
-		$.get(OC.generateUrl('apps/' + OCA.Onlyoffice.AppName + '/ajax/url?filePath={filePath}',
+		axios.get(OC.generateUrl('apps/' + OCA.Onlyoffice.AppName + '/ajax/url?filePath={filePath}',
 			{
 				filePath,
-			}),
-		function onSuccess(response) {
-			if (response.error) {
-				OCA.Onlyoffice.showMessage(response.error, 'error')
-				return
-			}
+			}))
+			.then((response) => {
+				const data = response.data
+				if (data.error) {
+					OCA.Onlyoffice.showMessage(data.error, 'error')
+					return
+				}
 
-			OCA.Onlyoffice.docEditor.setMailMergeRecipients(response)
-		})
+				OCA.Onlyoffice.docEditor.setMailMergeRecipients(data)
+			})
 	}
 
 	OCA.Onlyoffice.editorReferenceSource = function(filePath) {
@@ -417,16 +428,16 @@
 			return
 		}
 
-		$.post(OC.generateUrl('apps/' + OCA.Onlyoffice.AppName + '/ajax/reference'),
-			{
-				path: filePath,
-			},
-			function onSuccess(response) {
-				if (response.error) {
-					OCA.Onlyoffice.showMessage(response.error, 'error')
+		axios.post(OC.generateUrl('apps/' + OCA.Onlyoffice.AppName + '/ajax/reference'), {
+			path: filePath,
+		})
+			.then((response) => {
+				const data = response.data
+				if (data.error) {
+					OCA.Onlyoffice.showMessage(data.error, 'error')
 					return
 				}
-				OCA.Onlyoffice.docEditor.setReferenceSource(response)
+				OCA.Onlyoffice.docEditor.setReferenceSource(data)
 			})
 	}
 
@@ -488,19 +499,20 @@
 
 	OCA.Onlyoffice.editorSetRequested = function(filePath) {
 		const documentSelectionType = this.documentSelectionType
-		$.get(OC.generateUrl('apps/' + OCA.Onlyoffice.AppName + '/ajax/url?filePath={filePath}',
+		axios.get(OC.generateUrl('apps/' + OCA.Onlyoffice.AppName + '/ajax/url?filePath={filePath}',
 			{
 				filePath,
-			}),
-		function onSuccess(response) {
-			if (response.error) {
-				OCP.Toast.error(response.error)
-				return
-			}
-			response.c = documentSelectionType
+			}))
+			.then((response) => {
+				const data = response.data
+				if (data.error) {
+					OCP.Toast.error(data.error)
+					return
+				}
+				data.c = documentSelectionType
 
-			OCA.Onlyoffice.docEditor.setRequestedDocument(response)
-		})
+				OCA.Onlyoffice.docEditor.setRequestedDocument(data)
+			})
 	}
 
 	OCA.Onlyoffice.onMakeActionLink = function(event) {
@@ -535,16 +547,16 @@
 		const operationType = typeof (event.data.c) !== 'undefined' ? event.data.c : null
 		switch (operationType) {
 		case 'info': {
-			$.get(OC.generateUrl('apps/' + OCA.Onlyoffice.AppName + '/ajax/userInfo?userIds={userIds}',
+			axios.get(OC.generateUrl('apps/' + OCA.Onlyoffice.AppName + '/ajax/userInfo?userIds={userIds}',
 				{
 					userIds: JSON.stringify(event.data.id),
-				}),
-			function onSuccess(response) {
-				OCA.Onlyoffice.docEditor.setUsers({
-					c: operationType,
-					users: response,
+				}))
+				.then((response) => {
+					OCA.Onlyoffice.docEditor.setUsers({
+						c: operationType,
+						users: response.data,
+					})
 				})
-			})
 			break
 		}
 		default: {
@@ -552,20 +564,20 @@
 			if (typeof (event.data.search) !== 'undefined') {
 				requestString += '&from=' + event.data.from + '&count=' + event.data.count + '&search=' + encodeURIComponent(event.data.search)
 			}
-			$.get(OC.generateUrl(requestString,
+			axios.get(OC.generateUrl(requestString,
 				{
 					fileId: OCA.Onlyoffice.fileId || 0,
-				}),
-			function onSuccess(response) {
-				OCA.Onlyoffice.docEditor.setUsers({
-					c: operationType,
-					users: response,
-					// support v9.0
-					total: 1 + (!event.data.count || response.length < event.data.count ? 0 : (event.data.from + event.data.count)),
-					// since v9.0.1
-					isPaginated: true,
+				}))
+				.then((response) => {
+					OCA.Onlyoffice.docEditor.setUsers({
+						c: operationType,
+						users: response.data,
+						// support v9.0
+						total: 1 + (!event.data.count || response.data.length < event.data.count ? 0 : (event.data.from + event.data.count)),
+						// since v9.0.1
+						isPaginated: true,
+					})
 				})
-			})
 		}
 		}
 	}
@@ -577,20 +589,20 @@
 
 		const fileId = OCA.Onlyoffice.fileId
 
-		$.post(OC.generateUrl('apps/' + OCA.Onlyoffice.AppName + '/ajax/mention'),
-			{
-				fileId,
-				anchor: JSON.stringify(actionLink),
-				comment,
-				emails,
-			},
-			function onSuccess(response) {
-				if (response.error) {
-					OCA.Onlyoffice.showMessage(response.error, 'error')
+		axios.post(OC.generateUrl('apps/' + OCA.Onlyoffice.AppName + '/ajax/mention'), {
+			fileId,
+			anchor: JSON.stringify(actionLink),
+			comment,
+			emails,
+		})
+			.then((response) => {
+				const data = response.data
+				if (data.error) {
+					OCA.Onlyoffice.showMessage(data.error, 'error')
 					return
 				}
 
-				OCA.Onlyoffice.showMessage(response.message)
+				OCA.Onlyoffice.showMessage(data.message)
 			})
 	}
 
@@ -599,19 +611,19 @@
 		const referenceData = event.data.referenceData
 		const path = event.data.path
 
-		$.post(OC.generateUrl('apps/' + OCA.Onlyoffice.AppName + '/ajax/reference'),
-			{
-				referenceData,
-				path,
-				link,
-			},
-			function onSuccess(response) {
-				if (response.error) {
-					OCA.Onlyoffice.showMessage(response.error, 'error')
+		axios.post(OC.generateUrl('apps/' + OCA.Onlyoffice.AppName + '/ajax/reference'), {
+			referenceData,
+			path,
+			link,
+		})
+			.then((response) => {
+				const data = response.data
+				if (data.error) {
+					OCA.Onlyoffice.showMessage(data.error, 'error')
 					return
 				}
 
-				OCA.Onlyoffice.docEditor.setReferenceData(response)
+				OCA.Onlyoffice.docEditor.setReferenceData(data)
 			})
 	}
 
@@ -644,29 +656,21 @@
 
 	OCA.Onlyoffice.onMetaChange = function(event) {
 		if (event.data.favorite !== undefined) {
-			$.ajax({
-				url: OC.generateUrl('apps/files/api/v1/files' + OC.encodePath(OCA.Onlyoffice.filePath)),
-				type: 'post',
-				data: JSON.stringify({
-					tags: event.data.favorite ? [OC.TAG_FAVORITE] : [],
-				}),
-				contentType: 'application/json',
-				dataType: 'json',
-				success() {
-					OCA.Onlyoffice.docEditor.setFavorite(event.data.favorite)
-				},
+			axios.post(OC.generateUrl('apps/files/api/v1/files' + OC.encodePath(OCA.Onlyoffice.filePath)), {
+				tags: event.data.favorite ? [OC.TAG_FAVORITE] : [],
 			})
+				.then(() => {
+					OCA.Onlyoffice.docEditor.setFavorite(event.data.favorite)
+				})
 		}
 	}
 
 	OCA.Onlyoffice.onRequestRefreshFile = function() {
 		const configUrl = OCA.Onlyoffice.getConfigUrl()
-		$.ajax({
-			url: configUrl,
-			success: function onSuccess(config) {
-				OCA.Onlyoffice.docEditor.refreshFile(config)
-			},
-		})
+		axios.get(configUrl)
+			.then((response) => {
+				OCA.Onlyoffice.docEditor.refreshFile(response.data)
+			})
 	}
 
 	OCA.Onlyoffice.showMessage = function(message, type = 'success', props = null) {
@@ -703,14 +707,14 @@
 			data = { error: response.error }
 		} else {
 			let currentVersion = 0
-			$.each(response, function(i, fileVersion) {
+			response.forEach((fileVersion, i) => {
 				if (fileVersion.version >= currentVersion) {
 					currentVersion = fileVersion.version
 				}
 
 				fileVersion.created = moment(fileVersion.created * 1000).format('L LTS')
 				if (fileVersion.changes) {
-					$.each(fileVersion.changes, function(j, change) {
+					fileVersion.changes.forEach((change, j) => {
 						change.created = moment(change.created + '+00:00').format('L LTS')
 					})
 				}
@@ -733,12 +737,13 @@
 			return
 		}
 
-		const headerHeight = $('#header').length > 0 ? $('#header').height() : 50
-		const wrapEl = $('#app>iframe')
-		if (wrapEl.length > 0) {
-			wrapEl[0].style.height = (screen.availHeight - headerHeight) + 'px'
+		const header = document.getElementById('header')
+		const headerHeight = header ? header.offsetHeight : 50
+		const wrapEl = document.querySelector('#app>iframe')
+		if (wrapEl) {
+			wrapEl.style.height = (screen.availHeight - headerHeight) + 'px'
 			window.scrollTo(0, -1)
-			wrapEl[0].style.height = (window.top.innerHeight - headerHeight) + 'px'
+			wrapEl.style.height = (window.top.innerHeight - headerHeight) + 'px'
 		}
 	}
 
@@ -769,7 +774,7 @@
 			params.push('shareToken=' + encodeURIComponent(OCA.Onlyoffice.shareToken))
 		}
 		if (OCA.Onlyoffice.directToken) {
-			$('html').addClass('onlyoffice-full-page')
+			document.documentElement.classList.add('onlyoffice-full-page')
 			params.push('directToken=' + encodeURIComponent(OCA.Onlyoffice.directToken))
 		}
 		if (OCA.Onlyoffice.template) {
@@ -802,4 +807,4 @@
 
 	OCA.Onlyoffice.InitEditor()
 
-})(jQuery, OCA)
+})(OCA)

--- a/src/listener.js
+++ b/src/listener.js
@@ -26,23 +26,31 @@
  *
  */
 
-/* global _, $ */
+/* global _ */
 
 /**
  * @param {object} OCA Nextcloud OCA object
  */
 (function(OCA) {
 
+	const getFavIconHref = () => {
+		const link = document.querySelector('link[rel="icon"]')
+		return link ? link.getAttribute('href') : null
+	}
+
 	OCA.Onlyoffice = _.extend({
 		AppName: 'onlyoffice',
 		frameSelector: null,
 		titleBase: window.document.title,
-		favIconBase: $('link[rel="icon"]').attr('href'),
+		favIconBase: getFavIconHref(),
 	}, OCA.Onlyoffice)
 
 	OCA.Onlyoffice.onRequestClose = function() {
 
-		$(OCA.Onlyoffice.frameSelector).remove()
+		const frame = document.querySelector(OCA.Onlyoffice.frameSelector)
+		if (frame) {
+			frame.remove()
+		}
 
 		if (OCA.Viewer && OCA.Viewer.close) {
 			OCA.Viewer.close()
@@ -58,7 +66,10 @@
 		OC.dialogs.filepicker(t(OCA.Onlyoffice.AppName, 'Save as'),
 			function(fileDir) {
 				saveData.dir = fileDir
-				$(OCA.Onlyoffice.frameSelector)[0].contentWindow.OCA.Onlyoffice.editorSaveAs(saveData)
+				const frame = document.querySelector(OCA.Onlyoffice.frameSelector)
+				if (frame && frame.contentWindow) {
+					frame.contentWindow.OCA.Onlyoffice.editorSaveAs(saveData)
+				}
 			},
 			false,
 			'httpd/unix-directory',
@@ -68,19 +79,25 @@
 	}
 
 	OCA.Onlyoffice.onRequestInsertImage = function(imageMimes) {
-		OC.dialogs.filepicker(t(OCA.Onlyoffice.AppName, 'Insert image'),
-			$(OCA.Onlyoffice.frameSelector)[0].contentWindow.OCA.Onlyoffice.editorInsertImage,
-			false,
-			imageMimes,
-			true)
+		const frame = document.querySelector(OCA.Onlyoffice.frameSelector)
+		if (frame && frame.contentWindow) {
+			OC.dialogs.filepicker(t(OCA.Onlyoffice.AppName, 'Insert image'),
+				frame.contentWindow.OCA.Onlyoffice.editorInsertImage,
+				false,
+				imageMimes,
+				true)
+		}
 	}
 
 	OCA.Onlyoffice.onRequestMailMergeRecipients = function(recipientMimes) {
-		OC.dialogs.filepicker(t(OCA.Onlyoffice.AppName, 'Select recipients'),
-			$(OCA.Onlyoffice.frameSelector)[0].contentWindow.OCA.Onlyoffice.editorSetRecipient,
-			false,
-			recipientMimes,
-			true)
+		const frame = document.querySelector(OCA.Onlyoffice.frameSelector)
+		if (frame && frame.contentWindow) {
+			OC.dialogs.filepicker(t(OCA.Onlyoffice.AppName, 'Select recipients'),
+				frame.contentWindow.OCA.Onlyoffice.editorSetRecipient,
+				false,
+				recipientMimes,
+				true)
+		}
 	}
 
 	OCA.Onlyoffice.onRequestSelectDocument = function(revisedMimes, documentSelectionType) {
@@ -98,19 +115,25 @@
 		default:
 			title = t(OCA.Onlyoffice.AppName, 'Select file')
 		}
-		OC.dialogs.filepicker(title,
-			$(OCA.Onlyoffice.frameSelector)[0].contentWindow.OCA.Onlyoffice.editorSetRequested.bind({ documentSelectionType }),
-			false,
-			revisedMimes,
-			true)
+		const frame = document.querySelector(OCA.Onlyoffice.frameSelector)
+		if (frame && frame.contentWindow) {
+			OC.dialogs.filepicker(title,
+				frame.contentWindow.OCA.Onlyoffice.editorSetRequested.bind({ documentSelectionType }),
+				false,
+				revisedMimes,
+				true)
+		}
 	}
 
 	OCA.Onlyoffice.onRequestReferenceSource = function(referenceSourceMimes) {
-		OC.dialogs.filepicker(t(OCA.Onlyoffice.AppName, 'Select data source'),
-			$(OCA.Onlyoffice.frameSelector)[0].contentWindow.OCA.Onlyoffice.editorReferenceSource,
-			false,
-			referenceSourceMimes,
-			true)
+		const frame = document.querySelector(OCA.Onlyoffice.frameSelector)
+		if (frame && frame.contentWindow) {
+			OC.dialogs.filepicker(t(OCA.Onlyoffice.AppName, 'Select data source'),
+				frame.contentWindow.OCA.Onlyoffice.editorReferenceSource,
+				false,
+				referenceSourceMimes,
+				true)
+		}
 	}
 
 	OCA.Onlyoffice.onDocumentReady = function() {
@@ -118,7 +141,10 @@
 	}
 
 	OCA.Onlyoffice.changeFavicon = function(favicon) {
-		$('link[rel="icon"]').attr('href', favicon)
+		const link = document.querySelector('link[rel="icon"]')
+		if (link) {
+			link.setAttribute('href', favicon)
+		}
 	}
 
 	OCA.Onlyoffice.setViewport = function() {
@@ -137,8 +163,9 @@
 	}
 
 	window.addEventListener('message', function(event) {
-		if (!$(OCA.Onlyoffice.frameSelector).length
-			|| $(OCA.Onlyoffice.frameSelector)[0].contentWindow !== event.source
+		const frame = document.querySelector(OCA.Onlyoffice.frameSelector)
+		if (!frame
+			|| frame.contentWindow !== event.source
 			|| !event.data.method) {
 			return
 		}
@@ -184,7 +211,8 @@
 	}, false)
 
 	window.addEventListener('popstate', function(event) {
-		if ($(OCA.Onlyoffice.frameSelector).length) {
+		const frame = document.querySelector(OCA.Onlyoffice.frameSelector)
+		if (frame) {
 			OCA.Onlyoffice.onRequestClose()
 		}
 	})

--- a/src/main.js
+++ b/src/main.js
@@ -33,17 +33,20 @@
 
 import {
 	File,
-	FileAction,
 	registerFileAction,
 	Permission,
 	DefaultType,
 	addNewFileMenuEntry,
-	davGetClient,
-	davRootPath,
-	davGetDefaultPropfind,
-	davResultToNode,
 } from '@nextcloud/files'
+import {
+	getClient,
+	getRootPath,
+	getDefaultPropfind,
+	resultToNode,
+} from '@nextcloud/files/dav'
 import { emit } from '@nextcloud/event-bus'
+import { generateUrl } from '@nextcloud/router'
+import { getCurrentUser } from '@nextcloud/auth'
 import AppDarkSvg from '!!raw-loader!../img/app-dark.svg'
 import NewDocxSvg from '!!raw-loader!../img/new-docx.svg'
 import NewXlsxSvg from '!!raw-loader!../img/new-xlsx.svg'
@@ -88,10 +91,10 @@ import { loadState } from '@nextcloud/initial-state'
 					mtime: new Date(),
 					mime: response.mimetype,
 					name: response.name,
-					owner: OC.getCurrentUser().uid || null,
+					owner: getCurrentUser()?.uid || null,
 					permissions: Permission.ALL,
 					type: 'file',
-					root: filesContext?.root || '/files/' + OC.getCurrentUser().uid,
+					root: filesContext?.root || '/files/' + getCurrentUser()?.uid,
 				})
 				emit('files:node:created', file)
 			} else {
@@ -128,7 +131,7 @@ import { loadState } from '@nextcloud/initial-state'
 			createData.shareToken = encodeURIComponent(getSharingToken())
 		}
 
-		$.post(OC.generateUrl('apps/' + OCA.Onlyoffice.AppName + '/ajax/new'),
+		$.post(generateUrl('apps/' + OCA.Onlyoffice.AppName + '/ajax/new'),
 			createData,
 			function onSuccess(response) {
 				if (response.error) {
@@ -161,14 +164,14 @@ import { loadState } from '@nextcloud/initial-state'
 		if (fileName) {
 			filePath = fileDir.replace(/\/$/, '') + '/' + fileName
 		}
-		let url = OC.generateUrl('/apps/' + OCA.Onlyoffice.AppName + '/{fileId}?filePath={filePath}',
+		let url = generateUrl('/apps/' + OCA.Onlyoffice.AppName + '/{fileId}?filePath={filePath}',
 			{
 				fileId,
 				filePath,
 			})
 
 		if (isPublicShare()) {
-			url = OC.generateUrl('apps/' + OCA.Onlyoffice.AppName + '/s/{shareToken}?fileId={fileId}',
+			url = generateUrl('apps/' + OCA.Onlyoffice.AppName + '/s/{shareToken}?fileId={fileId}',
 				{
 					shareToken: encodeURIComponent(getSharingToken()),
 					fileId,
@@ -327,7 +330,7 @@ import { loadState } from '@nextcloud/initial-state'
 			convertData.shareToken = encodeURIComponent(getSharingToken())
 		}
 
-		$.post(OC.generateUrl('apps/' + OCA.Onlyoffice.AppName + '/ajax/convert'),
+		$.post(generateUrl('apps/' + OCA.Onlyoffice.AppName + '/ajax/convert'),
 			convertData,
 			function onSuccess(response) {
 				if (response.error) {
@@ -400,7 +403,7 @@ import { loadState } from '@nextcloud/initial-state'
 						classes: 'primary',
 						click() {
 							const format = this.dataset.format
-							const downloadLink = OC.generateUrl('apps/' + OCA.Onlyoffice.AppName + '/downloadas?fileId={fileId}&toExtension={toExtension}', {
+							const downloadLink = generateUrl('apps/' + OCA.Onlyoffice.AppName + '/downloadas?fileId={fileId}&toExtension={toExtension}', {
 								fileId,
 								toExtension: format,
 							})
@@ -439,11 +442,11 @@ import { loadState } from '@nextcloud/initial-state'
 				const targetFolderPath = OC.dirname(filePath)
 
 				if (!dialogFileList) {
-					const results = await davGetClient().getDirectoryContents(davRootPath + targetFolderPath, {
+					const results = await getClient().getDirectoryContents(getRootPath() + targetFolderPath, {
 						details: true,
-						data: davGetDefaultPropfind(),
+						data: getDefaultPropfind(),
 					})
-					dialogFileList = results.data.map((result) => davResultToNode(result))
+					dialogFileList = results.data.map((result) => resultToNode(result))
 				}
 
 				if (type === 'target') {
@@ -556,7 +559,7 @@ import { loadState } from '@nextcloud/initial-state'
 				})
 			})
 		} else {
-			registerFileAction(new FileAction({
+			registerFileAction({
 				id: 'onlyoffice-open-def',
 				displayName: () => t(OCA.Onlyoffice.AppName, 'Open in ONLYOFFICE'),
 				iconSvgInline: () => AppDarkSvg,
@@ -573,9 +576,9 @@ import { loadState } from '@nextcloud/initial-state'
 				exec: OCA.Onlyoffice.FileClickExec,
 				default: DefaultType.HIDDEN,
 				order: -1,
-			}))
+			})
 
-			registerFileAction(new FileAction({
+			registerFileAction({
 				id: 'onlyoffice-open',
 				displayName: () => t(OCA.Onlyoffice.AppName, 'Open in ONLYOFFICE'),
 				iconSvgInline: () => AppDarkSvg,
@@ -592,9 +595,9 @@ import { loadState } from '@nextcloud/initial-state'
 				exec(file, view, dir) {
 					OCA.Onlyoffice.FileClickExec(file, view, dir, false)
 				},
-			}))
+			})
 
-			registerFileAction(new FileAction({
+			registerFileAction({
 				id: 'onlyoffice-convert',
 				displayName: () => t(OCA.Onlyoffice.AppName, 'Convert with ONLYOFFICE'),
 				iconSvgInline: () => AppDarkSvg,
@@ -618,9 +621,9 @@ import { loadState } from '@nextcloud/initial-state'
 					return true
 				},
 				exec: OCA.Onlyoffice.FileConvertClickExec,
-			}))
+			})
 
-			registerFileAction(new FileAction({
+			registerFileAction({
 				id: 'onlyoffice-create-form',
 				displayName: () => t(OCA.Onlyoffice.AppName, 'Create form'),
 				iconSvgInline: () => AppDarkSvg,
@@ -644,10 +647,10 @@ import { loadState } from '@nextcloud/initial-state'
 					return true
 				},
 				exec: OCA.Onlyoffice.CreateFormClickExec,
-			}))
+			})
 
 			if (!isPublicShare()) {
-				registerFileAction(new FileAction({
+				registerFileAction({
 					id: 'onlyoffice-download-as',
 					displayName: () => t(OCA.Onlyoffice.AppName, 'Download as'),
 					iconSvgInline: () => AppDarkSvg,
@@ -671,7 +674,7 @@ import { loadState } from '@nextcloud/initial-state'
 						return true
 					},
 					exec: OCA.Onlyoffice.DownloadClickExec,
-				}))
+				})
 			}
 		}
 	}
@@ -877,7 +880,7 @@ import { loadState } from '@nextcloud/initial-state'
 				return
 			}
 
-			const editorUrl = OC.generateUrl('apps/' + OCA.Onlyoffice.AppName + '/s/' + encodeURIComponent(getSharingToken()))
+			const editorUrl = generateUrl('apps/' + OCA.Onlyoffice.AppName + '/s/' + encodeURIComponent(getSharingToken()))
 
 			if (_oc_appswebroots.richdocuments
 				|| (_oc_appswebroots.files_pdfviewer && extension === 'pdf')

--- a/src/main.js
+++ b/src/main.js
@@ -29,7 +29,7 @@
 /* eslint-disable import/no-webpack-loader-syntax */
 /* eslint-disable import/no-unresolved */
 
-/* global _, $, _oc_appswebroots */
+/* global _, _oc_appswebroots */
 
 import {
 	File,
@@ -47,6 +47,7 @@ import {
 import { emit } from '@nextcloud/event-bus'
 import { generateUrl } from '@nextcloud/router'
 import { getCurrentUser } from '@nextcloud/auth'
+import axios from '@nextcloud/axios'
 import AppDarkSvg from '!!raw-loader!../img/app-dark.svg'
 import NewDocxSvg from '!!raw-loader!../img/new-docx.svg'
 import NewXlsxSvg from '!!raw-loader!../img/new-xlsx.svg'
@@ -131,32 +132,37 @@ import { loadState } from '@nextcloud/initial-state'
 			createData.shareToken = encodeURIComponent(getSharingToken())
 		}
 
-		$.post(generateUrl('apps/' + OCA.Onlyoffice.AppName + '/ajax/new'),
-			createData,
-			function onSuccess(response) {
-				if (response.error) {
+		axios.post(generateUrl('apps/' + OCA.Onlyoffice.AppName + '/ajax/new'), createData)
+			.then((response) => {
+				const data = response.data
+				if (data.error) {
 					if (winEditor) {
 						winEditor.close()
 					}
-					OCP.Toast.error(response.error)
+					OCP.Toast.error(data.error)
 					return
 				}
 
-				callback(response)
+				callback(data)
 
 				if (open) {
-					const fileName = response.name
-					OCA.Onlyoffice.OpenEditor(response.id, dir, fileName, winEditor)
+					const fileName = data.name
+					OCA.Onlyoffice.OpenEditor(data.id, dir, fileName, winEditor)
 
 					OCA.Onlyoffice.context = {
-						fileName: response.name,
+						fileName: data.name,
 						dir,
 					}
 				}
 
 				OCP.Toast.success(t(OCA.Onlyoffice.AppName, 'File created'))
-			},
-		)
+			})
+			.catch((error) => {
+				if (winEditor) {
+					winEditor.close()
+				}
+				OCP.Toast.error(error.message || t(OCA.Onlyoffice.AppName, 'Failed to create file'))
+			})
 	}
 
 	OCA.Onlyoffice.OpenEditor = function(fileId, fileDir, fileName, winEditor, isDefault = true) {
@@ -206,21 +212,34 @@ import { loadState } from '@nextcloud/initial-state'
 				return
 			}
 			OCA.Onlyoffice.frameSelector = '#onlyofficeFrame'
-			const $iframe = $('<div class="onlyoffice-iframe-container"><iframe id="onlyofficeFrame" nonce="' + btoa(OC.requestToken) + '" scrolling="no" allowfullscreen src="' + url + '&inframe=true" /></div>')
+		const iframeContainer = document.createElement('div')
+		iframeContainer.className = 'onlyoffice-iframe-container'
+		const iframe = document.createElement('iframe')
+		iframe.id = 'onlyofficeFrame'
+		iframe.setAttribute('nonce', btoa(OC.requestToken))
+		iframe.setAttribute('scrolling', 'no')
+		iframe.setAttribute('allowfullscreen', '')
+		iframe.src = url + '&inframe=true'
+		iframeContainer.appendChild(iframe)
 
-			const frameContainer = $('#app-content').length > 0 ? $('#app-content') : $('#app-content-vue')
-			frameContainer.append($iframe)
+		const frameContainer = document.getElementById('app-content') || document.getElementById('app-content-vue')
+		if (frameContainer) {
+			frameContainer.appendChild(iframeContainer)
+		}
 
-			$('body').addClass('onlyoffice-inline')
-
+		document.body.classList.add('onlyoffice-inline')
 			if (OCA.Files.Sidebar) {
 				OCA.Files.Sidebar.close()
 			}
 
-			const scrollTop = $('#app-content').scrollTop()
-			$(OCA.Onlyoffice.frameSelector).css('top', scrollTop)
+		const appContentElement = document.getElementById('app-content')
+		const scrollTop = appContentElement ? appContentElement.scrollTop : 0
+		const frameElement = document.querySelector(OCA.Onlyoffice.frameSelector)
+		if (frameElement) {
+			frameElement.style.top = scrollTop + 'px'
+		}
 
-			window.OCP?.Files?.Router?.goToRoute(
+		window.OCP?.Files?.Router?.goToRoute(
 				null, // use default route
 				{ view: 'files', fileid: fileId },
 				{ ...OCP.Files.Router.query, openfile: 'true' },
@@ -229,7 +248,7 @@ import { loadState } from '@nextcloud/initial-state'
 	}
 
 	OCA.Onlyoffice.CloseEditor = function() {
-		$('body').removeClass('onlyoffice-inline')
+		document.body.classList.remove('onlyoffice-inline')
 
 		const iframeContainer = document.querySelector('.onlyoffice-iframe-container')
 		if (iframeContainer !== null) {
@@ -251,7 +270,8 @@ import { loadState } from '@nextcloud/initial-state'
 
 	OCA.Onlyoffice.OpenShareDialog = function() {
 		if (OCA.Onlyoffice.context) {
-			if (!$('#app-sidebar-vue').is(':visible')) {
+			const sidebarElement = document.getElementById('app-sidebar-vue')
+			if (!sidebarElement || sidebarElement.offsetParent === null) {
 				OCA.Files.Sidebar.open(OCA.Onlyoffice.context.dir + '/' + OCA.Onlyoffice.context.fileName)
 				OCA.Files.Sidebar.setActiveTab('sharing')
 			} else {
@@ -262,7 +282,8 @@ import { loadState } from '@nextcloud/initial-state'
 
 	OCA.Onlyoffice.RefreshVersionsDialog = function() {
 		if (OCA.Onlyoffice.context) {
-			if ($('#app-sidebar-vue').is(':visible')) {
+			const sidebarElement = document.getElementById('app-sidebar-vue')
+			if (sidebarElement && sidebarElement.offsetParent !== null) {
 				OCA.Files.Sidebar.close()
 				OCA.Files.Sidebar.open(OCA.Onlyoffice.context.dir + '/' + OCA.Onlyoffice.context.fileName)
 				OCA.Files.Sidebar.setActiveTab('versionsTabView')
@@ -330,17 +351,20 @@ import { loadState } from '@nextcloud/initial-state'
 			convertData.shareToken = encodeURIComponent(getSharingToken())
 		}
 
-		$.post(generateUrl('apps/' + OCA.Onlyoffice.AppName + '/ajax/convert'),
-			convertData,
-			function onSuccess(response) {
-				if (response.error) {
-					OCP.Toast.error(response.error)
+		axios.post(generateUrl('apps/' + OCA.Onlyoffice.AppName + '/ajax/convert'), convertData)
+			.then((response) => {
+				const data = response.data
+				if (data.error) {
+					OCP.Toast.error(data.error)
 					return
 				}
 
-				callback(response)
+				callback(data)
 
 				OCP.Toast.success(t(OCA.Onlyoffice.AppName, 'File has been converted. Its content might look different.'))
+			})
+			.catch((error) => {
+				OCP.Toast.error(error.message || t(OCA.Onlyoffice.AppName, 'Failed to convert file'))
 			})
 	}
 
@@ -357,46 +381,52 @@ import { loadState } from '@nextcloud/initial-state'
 	}
 
 	OCA.Onlyoffice.Download = function(fileName, fileId) {
-		$.get(OC.filePath(OCA.Onlyoffice.AppName, 'templates', 'downloadPicker.html'),
-			function(tmpl) {
-				const dialog = $(tmpl).octemplate({
+		axios.get(OC.filePath(OCA.Onlyoffice.AppName, 'templates', 'downloadPicker.html'))
+			.then((response) => {
+				const tmpl = response.data
+				const tempDiv = document.createElement('div')
+				tempDiv.innerHTML = tmpl
+				const dialog = window.$(tempDiv.firstElementChild).octemplate({
 					dialog_name: 'download-picker',
 					dialog_title: t('onlyoffice', 'Download as'),
 				})
 
-				$(dialog[0].querySelectorAll('p')).text(t(OCA.Onlyoffice.AppName, 'Choose a format to convert {fileName}', { fileName }))
+				const dialogElement = dialog[0]
+				const pElement = dialogElement.querySelector('p')
+				if (pElement) {
+					pElement.textContent = t(OCA.Onlyoffice.AppName, 'Choose a format to convert {fileName}', { fileName })
+				}
 
 				const extension = OCA.Onlyoffice.getFileExtension(fileName)
-				const selectNode = dialog[0].querySelectorAll('select')[0]
-				const optionNodeOrigin = selectNode.querySelectorAll('option')[0]
+				const selectNode = dialogElement.querySelector('select')
+				const optionNodeOrigin = selectNode.querySelector('option')
 
-				$(optionNodeOrigin).attr('data-value', extension)
-				$(optionNodeOrigin).text(t(OCA.Onlyoffice.AppName, 'Origin format'))
+				optionNodeOrigin.setAttribute('data-value', extension)
+				optionNodeOrigin.textContent = t(OCA.Onlyoffice.AppName, 'Origin format')
 
-				dialog[0].dataset.format = extension
+				dialogElement.dataset.format = extension
 				selectNode.onchange = function() {
-					dialog[0].dataset.format = $('#onlyoffice-download-select option:selected').attr('data-value')
+					const selectedOption = selectNode.querySelector('option:checked')
+					dialogElement.dataset.format = selectedOption.getAttribute('data-value')
 				}
 
 				OCA.Onlyoffice.setting.formats[extension].saveas.forEach(ext => {
 					const optionNode = optionNodeOrigin.cloneNode(true)
-
-					$(optionNode).attr('data-value', ext)
-					$(optionNode).text(ext)
-
+					optionNode.setAttribute('data-value', ext)
+					optionNode.textContent = ext
 					selectNode.append(optionNode)
 				})
 
-				$('body').append(dialog)
+				document.body.appendChild(dialogElement)
 
-				$('#download-picker').ocdialog({
+				window.$('#download-picker').ocdialog({
 					closeOnEscape: true,
 					modal: true,
 					buttons: [{
 						text: t('core', 'Cancel'),
 						classes: 'cancel',
 						click() {
-							$(this).ocdialog('close')
+							window.$(this).ocdialog('close')
 						},
 					}, {
 						text: t('onlyoffice', 'Download'),
@@ -409,10 +439,13 @@ import { loadState } from '@nextcloud/initial-state'
 							})
 
 							location.href = downloadLink
-							$(this).ocdialog('close')
+							window.$(this).ocdialog('close')
 						},
 					}],
 				})
+			})
+			.catch((error) => {
+				OCP.Toast.error(error.message || t(OCA.Onlyoffice.AppName, 'Failed to load template'))
 			})
 	}
 
@@ -504,9 +537,9 @@ import { loadState } from '@nextcloud/initial-state'
 		}
 
 		if (OCA.Files && OCA.Files.fileActions) {
-			$.each(formats, function(ext, config) {
+			Object.entries(formats).forEach(([ext, config]) => {
 				if (!config.mime) {
-					return true
+					return
 				}
 
 				const mimeTypes = config.mime
@@ -563,13 +596,13 @@ import { loadState } from '@nextcloud/initial-state'
 				id: 'onlyoffice-open-def',
 				displayName: () => t(OCA.Onlyoffice.AppName, 'Open in ONLYOFFICE'),
 				iconSvgInline: () => AppDarkSvg,
-				enabled: (files) => {
-					const config = getConfig(files[0])
+				enabled: ({ nodes }) => {
+					const config = getConfig(nodes[0])
 
 					if (!config) return false
 					if (!config.def) return false
 
-					if (Permission.READ !== (files[0].permissions & Permission.READ)) { return false }
+					if (Permission.READ !== (nodes[0].permissions & Permission.READ)) { return false }
 
 					return true
 				},
@@ -582,13 +615,13 @@ import { loadState } from '@nextcloud/initial-state'
 				id: 'onlyoffice-open',
 				displayName: () => t(OCA.Onlyoffice.AppName, 'Open in ONLYOFFICE'),
 				iconSvgInline: () => AppDarkSvg,
-				enabled: (files) => {
-					const config = getConfig(files[0])
+				enabled: ({ nodes }) => {
+					const config = getConfig(nodes[0])
 
 					if (!config) return false
 					if (config.def) return false
 
-					if (Permission.READ !== (files[0].permissions & Permission.READ)) { return false }
+					if (Permission.READ !== (nodes[0].permissions & Permission.READ)) { return false }
 
 					return true
 				},
@@ -601,19 +634,19 @@ import { loadState } from '@nextcloud/initial-state'
 				id: 'onlyoffice-convert',
 				displayName: () => t(OCA.Onlyoffice.AppName, 'Convert with ONLYOFFICE'),
 				iconSvgInline: () => AppDarkSvg,
-				enabled: (files) => {
-					const config = getConfig(files[0])
+				enabled: ({ nodes }) => {
+					const config = getConfig(nodes[0])
 
 					if (!config) return false
 					if (!config.conv) return false
 
 					const required = isPublicShare() ? Permission.UPDATE : Permission.READ
-					if (required !== (files[0].permissions & required)) { return false }
+					if (required !== (nodes[0].permissions & required)) { return false }
 
-					if (files[0].attributes['mount-type'] === 'shared') {
-						if (required !== (files[0].attributes['share-permissions'] & required)) { return false }
+					if (nodes[0].attributes['mount-type'] === 'shared') {
+						if (required !== (nodes[0].attributes['share-permissions'] & required)) { return false }
 
-						const attributes = JSON.parse(files[0].attributes['share-attributes'])
+						const attributes = JSON.parse(nodes[0].attributes['share-attributes'])
 						const downloadAttribute = attributes.find((attribute) => attribute.scope === 'permissions' && attribute.key === 'download')
 						if (downloadAttribute !== undefined && downloadAttribute.enabled === false) { return false }
 					}
@@ -627,19 +660,19 @@ import { loadState } from '@nextcloud/initial-state'
 				id: 'onlyoffice-create-form',
 				displayName: () => t(OCA.Onlyoffice.AppName, 'Create form'),
 				iconSvgInline: () => AppDarkSvg,
-				enabled: (files) => {
-					const config = getConfig(files[0])
+				enabled: ({ nodes }) => {
+					const config = getConfig(nodes[0])
 
 					if (!config) return false
 					if (!config.createForm) return false
 
 					const required = isPublicShare() ? Permission.UPDATE : Permission.READ
-					if (required !== (files[0].permissions & required)) { return false }
+					if (required !== (nodes[0].permissions & required)) { return false }
 
-					if (files[0].attributes['mount-type'] === 'shared') {
-						if (required !== (files[0].attributes['share-permissions'] & required)) { return false }
+					if (nodes[0].attributes['mount-type'] === 'shared') {
+						if (required !== (nodes[0].attributes['share-permissions'] & required)) { return false }
 
-						const attributes = JSON.parse(files[0].attributes['share-attributes'])
+						const attributes = JSON.parse(nodes[0].attributes['share-attributes'])
 						const downloadAttribute = attributes.find((attribute) => attribute.scope === 'permissions' && attribute.key === 'download')
 						if (downloadAttribute !== undefined && downloadAttribute.enabled === false) { return false }
 					}
@@ -654,19 +687,19 @@ import { loadState } from '@nextcloud/initial-state'
 					id: 'onlyoffice-download-as',
 					displayName: () => t(OCA.Onlyoffice.AppName, 'Download as'),
 					iconSvgInline: () => AppDarkSvg,
-					enabled: (files) => {
+					enabled: ({ nodes }) => {
 						if (OCA.Onlyoffice.setting.disableDownload) {
 							return false
 						}
-						const config = getConfig(files[0])
+						const config = getConfig(nodes[0])
 
 						if (!config) return false
 						if (!config.saveas) return false
 
-						if (Permission.READ !== (files[0].permissions & Permission.READ)) { return false }
+						if (Permission.READ !== (nodes[0].permissions & Permission.READ)) { return false }
 
-						if (files[0].attributes['mount-type'] === 'shared') {
-							const attributes = JSON.parse(files[0].attributes['share-attributes'])
+						if (nodes[0].attributes['mount-type'] === 'shared') {
+							const attributes = JSON.parse(nodes[0].attributes['share-attributes'])
 							const downloadAttribute = attributes.find((attribute) => attribute.scope === 'permissions' && attribute.key === 'download')
 							if (downloadAttribute !== undefined && downloadAttribute.enabled === false) { return false }
 						}
@@ -895,7 +928,10 @@ import { loadState } from '@nextcloud/initial-state'
 					button.target = '_blank'
 				}
 
-				$('#preview').prepend(button)
+			const previewElement = document.getElementById('preview')
+			if (previewElement) {
+				previewElement.prepend(button)
+			}
 			} else {
 				OCA.Onlyoffice.frameSelector = '#onlyofficeFrame'
 				const container = document.createElement('div')
@@ -909,7 +945,7 @@ import { loadState } from '@nextcloud/initial-state'
 				container.appendChild(iframe)
 				const appContent = document.querySelector('#app-content') || document.querySelector('#app-content-vue')
 				appContent.appendChild(container)
-				$('body').addClass('onlyoffice-inline')
+				document.body.classList.add('onlyoffice-inline')
 			}
 		} else {
 			OC.Plugins.register('OCA.Files.NewFileMenu', OCA.Onlyoffice.NewFileMenu)

--- a/src/main.js
+++ b/src/main.js
@@ -302,16 +302,17 @@ import { loadState } from '@nextcloud/initial-state'
 		OCA.Onlyoffice.context.fileName = fileName
 	}
 
-	OCA.Onlyoffice.FileClickExec = async function(file, view, dir, isDefault = true) {
+	OCA.Onlyoffice.FileClickExec = async function({ nodes }) {
 		if (OCA.Onlyoffice.context !== null && OCA.Onlyoffice.setting.sameTab && !OCA.Onlyoffice.Desktop) {
 			return null
 		}
 
-		OCA.Onlyoffice.OpenEditor(file.fileid, dir, file.basename, 0, isDefault)
+		const node = nodes[0]
+		OCA.Onlyoffice.OpenEditor(node.fileid, node.dirname, node.basename, 0)
 
 		OCA.Onlyoffice.context = {
-			fileName: file.basename,
-			dir,
+			fileName: node.basename,
+			dir: node.dirname,
 		}
 
 		return null

--- a/src/settings.js
+++ b/src/settings.js
@@ -26,25 +26,25 @@
  *
  */
 
-/* global _, jQuery */
+/* global _ */
 
 import { spawnDialog } from '@nextcloud/vue/functions/dialog'
 import { getRequestToken } from '@nextcloud/auth'
 import { generateFilePath } from '@nextcloud/router'
 import { defineAsyncComponent } from 'vue'
+import axios from '@nextcloud/axios'
 
 /**
- * @param {object} $ JQueryStatic object
  * @param {object} OC Nextcloud OCA object
  */
-(function($, OC) {
+(function(OC) {
 	// eslint-disable-next-line
 	__webpack_nonce__ = btoa(getRequestToken())
 
 	// eslint-disable-next-line
 	__webpack_public_path__ = generateFilePath('onlyoffice', '', 'js/')
 
-	$(document).ready(function() {
+	document.addEventListener('DOMContentLoaded', function() {
 		OCA.Onlyoffice = _.extend({}, OCA.Onlyoffice)
 		if (!OCA.Onlyoffice.AppName) {
 			OCA.Onlyoffice = {
@@ -53,51 +53,96 @@ import { defineAsyncComponent } from 'vue'
 		}
 
 		const advToogle = function() {
-			$('#onlyofficeSecretPanel').toggleClass('onlyoffice-hide')
-			$('#onlyofficeAdv .icon').toggleClass('icon-triangle-s icon-triangle-n')
-		}
-
-		if ($('#onlyofficeInternalUrl').val().length
-			|| $('#onlyofficeStorageUrl').val().length
-			|| $('#onlyofficeJwtHeader').val().length) {
-			advToogle()
-		}
-
-		$('#onlyofficeAdv').click(advToogle)
-
-		$('#onlyofficeGroups').prop('checked', $('#onlyofficeLimitGroups').val() !== '')
-
-		const groupListToggle = function() {
-			if ($('#onlyofficeGroups').prop('checked')) {
-				OC.Settings.setupGroupsSelect($('#onlyofficeLimitGroups'))
-			} else {
-				$('#onlyofficeLimitGroups').select2('destroy')
+			const secretPanel = document.getElementById('onlyofficeSecretPanel')
+			if (secretPanel) {
+				secretPanel.classList.toggle('onlyoffice-hide')
+			}
+			const advIcon = document.querySelector('#onlyofficeAdv .icon')
+			if (advIcon) {
+				advIcon.classList.toggle('icon-triangle-s')
+				advIcon.classList.toggle('icon-triangle-n')
 			}
 		}
 
-		$('#onlyofficeGroups').click(groupListToggle)
-		groupListToggle()
+		const internalUrl = document.getElementById('onlyofficeInternalUrl')
+		const storageUrl = document.getElementById('onlyofficeStorageUrl')
+		const jwtHeader = document.getElementById('onlyofficeJwtHeader')
+		if ((internalUrl && internalUrl.value.length)
+			|| (storageUrl && storageUrl.value.length)
+			|| (jwtHeader && jwtHeader.value.length)) {
+			advToogle()
+		}
 
+		const advButton = document.getElementById('onlyofficeAdv')
+		if (advButton) {
+			advButton.addEventListener('click', advToogle)
+		}
+
+		const groupsCheckbox = document.getElementById('onlyofficeGroups')
+		const limitGroupsSelect = document.getElementById('onlyofficeLimitGroups')
+		if (groupsCheckbox && limitGroupsSelect) {
+			groupsCheckbox.checked = limitGroupsSelect.value !== ''
+		}
+
+		const groupListToggle = function() {
+			if (groupsCheckbox && groupsCheckbox.checked) {
+				OC.Settings.setupGroupsSelect(window.$(limitGroupsSelect))
+			} else if (limitGroupsSelect) {
+				window.$(limitGroupsSelect).select2('destroy')
+			}
+		}
+
+		if (groupsCheckbox) {
+			groupsCheckbox.addEventListener('click', groupListToggle)
+			groupListToggle()
+		}
+
+		const demoCheckbox = document.getElementById('onlyofficeDemo')
 		const demoToggle = function() {
-			$('#onlyofficeAddrSettings input:not(#onlyofficeStorageUrl)').prop('disabled', $('#onlyofficeDemo').prop('checked'))
+			const addrInputs = document.querySelectorAll('#onlyofficeAddrSettings input:not(#onlyofficeStorageUrl)')
+			const isChecked = demoCheckbox && demoCheckbox.checked
+			addrInputs.forEach(input => {
+				input.disabled = isChecked
+			})
 		}
 
-		$('#onlyofficeDemo').click(demoToggle)
-		demoToggle()
+		if (demoCheckbox) {
+			demoCheckbox.addEventListener('click', demoToggle)
+			demoToggle()
+		}
 
+		const watermarkEnabledCheckbox = document.getElementById('onlyofficeWatermark_enabled')
+		const watermarkSettings = document.getElementById('onlyofficeWatermarkSettings')
 		const watermarkToggle = function() {
-			$('#onlyofficeWatermarkSettings').toggleClass('onlyoffice-hide', !$('#onlyofficeWatermark_enabled').prop('checked'))
+			if (watermarkSettings) {
+				const isChecked = watermarkEnabledCheckbox && watermarkEnabledCheckbox.checked
+				watermarkSettings.classList.toggle('onlyoffice-hide', !isChecked)
+			}
 		}
 
-		$('#onlyofficeWatermark_enabled').click(watermarkToggle)
+		if (watermarkEnabledCheckbox) {
+			watermarkEnabledCheckbox.addEventListener('click', watermarkToggle)
+		}
 
-		$('#onlyofficeWatermark_shareAll').click(function() {
-			$('#onlyofficeWatermark_shareRead').parent().toggleClass('onlyoffice-hide')
-		})
+		const watermarkShareAll = document.getElementById('onlyofficeWatermark_shareAll')
+		if (watermarkShareAll) {
+			watermarkShareAll.addEventListener('click', function() {
+				const watermarkShareRead = document.getElementById('onlyofficeWatermark_shareRead')
+				if (watermarkShareRead && watermarkShareRead.parentElement) {
+					watermarkShareRead.parentElement.classList.toggle('onlyoffice-hide')
+				}
+			})
+		}
 
-		$('#onlyofficeWatermark_linkAll').click(function() {
-			$('#onlyofficeWatermark_link_sensitive').toggleClass('onlyoffice-hide')
-		})
+		const watermarkLinkAll = document.getElementById('onlyofficeWatermark_linkAll')
+		if (watermarkLinkAll) {
+			watermarkLinkAll.addEventListener('click', function() {
+				const watermarkLinkSensitive = document.getElementById('onlyofficeWatermark_link_sensitive')
+				if (watermarkLinkSensitive) {
+					watermarkLinkSensitive.classList.toggle('onlyoffice-hide')
+				}
+			})
+		}
 
 		const watermarkGroupLists = [
 			'allGroups',
@@ -110,11 +155,13 @@ import { defineAsyncComponent } from 'vue'
 
 		const watermarkNodeBehaviour = function(watermark) {
 			const watermarkListToggle = function() {
-				if ($('#onlyofficeWatermark_' + watermark).prop('checked')) {
+				const watermarkCheckbox = document.getElementById('onlyofficeWatermark_' + watermark)
+				if (watermarkCheckbox && watermarkCheckbox.checked) {
 					if (watermark.indexOf('Group') >= 0) {
-						OC.Settings.setupGroupsSelect($('#onlyofficeWatermark_' + watermark + 'List'))
+						const listElement = document.getElementById('onlyofficeWatermark_' + watermark + 'List')
+						OC.Settings.setupGroupsSelect(window.$(listElement))
 					} else {
-						$('#onlyofficeWatermark_' + watermark + 'List').select2({
+						window.$('#onlyofficeWatermark_' + watermark + 'List').select2({
 							allowClear: true,
 							closeOnSelect: false,
 							multiple: true,
@@ -127,7 +174,7 @@ import { defineAsyncComponent } from 'vue'
 								})
 							}, 100, true),
 							initSelection(element, callback) {
-								const selection = ($(element).val() || []).split('|').map(function(tagId) {
+								const selection = (element.value || '').split('|').map(function(tagId) {
 									return OC.SystemTags.collection.get(tagId)
 								})
 								callback(selection)
@@ -147,168 +194,214 @@ import { defineAsyncComponent } from 'vue'
 						})
 					}
 				} else {
-					$('#onlyofficeWatermark_' + watermark + 'List').select2('destroy')
+					const listElement = document.getElementById('onlyofficeWatermark_' + watermark + 'List')
+					if (listElement) {
+						window.$(listElement).select2('destroy')
+					}
 				}
 			}
 
-			$('#onlyofficeWatermark_' + watermark).click(watermarkListToggle)
-			watermarkListToggle()
+			const watermarkCheckbox = document.getElementById('onlyofficeWatermark_' + watermark)
+			if (watermarkCheckbox) {
+				watermarkCheckbox.addEventListener('click', watermarkListToggle)
+				watermarkListToggle()
+			}
 		}
 
-		$.each(watermarkGroupLists, function(i, watermarkGroup) {
+		watermarkGroupLists.forEach((watermarkGroup) => {
 			watermarkNodeBehaviour(watermarkGroup)
 		})
 
 		if (OC.SystemTags && OC.SystemTags.collection) {
 			OC.SystemTags.collection.fetch({
 				success() {
-					$.each(watermarkTagLists, function(i, watermarkTag) {
+					watermarkTagLists.forEach((watermarkTag) => {
 						watermarkNodeBehaviour(watermarkTag)
 					})
 				},
 			})
 		}
 
-		const connectionError = document.getElementById('onlyofficeSettingsState').value
+		const connectionErrorEl = document.getElementById('onlyofficeSettingsState')
+		const connectionError = connectionErrorEl ? connectionErrorEl.value : ''
 		if (connectionError !== '') {
 			OCP.Toast.error(t(OCA.Onlyoffice.AppName, 'Error when trying to connect') + ' (' + connectionError + ')')
 		}
 
-		$('#onlyofficeAddrSave').click(function() {
-			$('.section-onlyoffice').addClass('icon-loading')
-			const onlyofficeUrl = $('#onlyofficeUrl').val().trim()
+		const addrSaveButton = document.getElementById('onlyofficeAddrSave')
+		if (addrSaveButton) {
+			addrSaveButton.addEventListener('click', function() {
+				const section = document.querySelector('.section-onlyoffice')
+				if (section) section.classList.add('icon-loading')
 
-			if (!onlyofficeUrl.length) {
-				$('#onlyofficeInternalUrl, #onlyofficeStorageUrl, #onlyofficeSecret, #onlyofficeJwtHeader').val('')
-			}
+				const onlyofficeUrl = (document.getElementById('onlyofficeUrl').value || '').trim()
 
-			const onlyofficeInternalUrl = ($('#onlyofficeInternalUrl').val() || '').trim()
-			const onlyofficeStorageUrl = ($('#onlyofficeStorageUrl').val() || '').trim()
-			const onlyofficeVerifyPeerOff = $('#onlyofficeVerifyPeerOff').prop('checked')
-			const onlyofficeSecret = ($('#onlyofficeSecret').val() || '').trim()
-			const jwtHeader = ($('#onlyofficeJwtHeader').val() || '').trim()
-			const demo = $('#onlyofficeDemo').prop('checked')
+				if (!onlyofficeUrl.length) {
+					const internalUrl = document.getElementById('onlyofficeInternalUrl')
+					const storageUrl = document.getElementById('onlyofficeStorageUrl')
+					const secret = document.getElementById('onlyofficeSecret')
+					const jwtHeader = document.getElementById('onlyofficeJwtHeader')
+					if (internalUrl) internalUrl.value = ''
+					if (storageUrl) storageUrl.value = ''
+					if (secret) secret.value = ''
+					if (jwtHeader) jwtHeader.value = ''
+				}
 
-			$.ajax({
-				method: 'PUT',
-				url: OC.generateUrl('apps/' + OCA.Onlyoffice.AppName + '/ajax/settings/address'),
-				data: {
-					documentserver: onlyofficeUrl,
-					documentserverInternal: onlyofficeInternalUrl,
-					storageUrl: onlyofficeStorageUrl,
-					verifyPeerOff: onlyofficeVerifyPeerOff,
-					secret: onlyofficeSecret,
-					jwtHeader,
-					demo,
-				},
-				success: function onSuccess(response) {
-					$('.section-onlyoffice').removeClass('icon-loading')
-					if (response && (response.documentserver != null || demo)) {
-						$('#onlyofficeUrl').val(response.documentserver)
-						$('#onlyofficeInternalUrl').val(response.documentserverInternal)
-						$('#onlyofficeStorageUrl').val(response.storageUrl)
-						$('#onlyofficeSecret').val(response.secret)
-						$('#onlyofficeJwtHeader').val(response.jwtHeader)
+				const onlyofficeInternalUrl = (document.getElementById('onlyofficeInternalUrl')?.value || '').trim()
+				const onlyofficeStorageUrl = (document.getElementById('onlyofficeStorageUrl')?.value || '').trim()
+				const verifyPeerOffCheckbox = document.getElementById('onlyofficeVerifyPeerOff')
+				const onlyofficeVerifyPeerOff = verifyPeerOffCheckbox ? verifyPeerOffCheckbox.checked : false
+				const onlyofficeSecret = (document.getElementById('onlyofficeSecret')?.value || '').trim()
+				const jwtHeader = (document.getElementById('onlyofficeJwtHeader')?.value || '').trim()
+				const demoCheckbox = document.getElementById('onlyofficeDemo')
+				const demo = demoCheckbox ? demoCheckbox.checked : false
 
-						$('.section-onlyoffice-common, .section-onlyoffice-templates, .section-onlyoffice-watermark').toggleClass('onlyoffice-hide', (response.documentserver == null && !demo) || !!response.error.length)
+			axios.put(OC.generateUrl('apps/' + OCA.Onlyoffice.AppName + '/ajax/settings/address'), {
+				documentserver: onlyofficeUrl,
+				documentserverInternal: onlyofficeInternalUrl,
+				storageUrl: onlyofficeStorageUrl,
+				verifyPeerOff: onlyofficeVerifyPeerOff,
+				secret: onlyofficeSecret,
+				jwtHeader,
+				demo,
+			})
+				.then((response) => {
+					const section = document.querySelector('.section-onlyoffice')
+					if (section) section.classList.remove('icon-loading')
 
-						const versionMessage = response.version ? (' (' + t(OCA.Onlyoffice.AppName, 'version') + ' ' + response.version + ')') : ''
+					const data = response.data
+					if (data && (data.documentserver != null || demo)) {
+						const urlInput = document.getElementById('onlyofficeUrl')
+						const internalUrlInput = document.getElementById('onlyofficeInternalUrl')
+						const storageUrlInput = document.getElementById('onlyofficeStorageUrl')
+						const secretInput = document.getElementById('onlyofficeSecret')
+						const jwtHeaderInput = document.getElementById('onlyofficeJwtHeader')
+						if (urlInput) urlInput.value = data.documentserver
+						if (internalUrlInput) internalUrlInput.value = data.documentserverInternal
+						if (storageUrlInput) storageUrlInput.value = data.storageUrl
+						if (secretInput) secretInput.value = data.secret
+						if (jwtHeaderInput) jwtHeaderInput.value = data.jwtHeader
 
-						if (response.error) {
-							OCP.Toast.error(t(OCA.Onlyoffice.AppName, 'Error when trying to connect') + ' (' + response.error + ')' + versionMessage)
+						const toggleSections = document.querySelectorAll('.section-onlyoffice-common, .section-onlyoffice-templates, .section-onlyoffice-watermark')
+						const shouldHide = (data.documentserver == null && !demo) || !!data.error.length
+						toggleSections.forEach(el => el.classList.toggle('onlyoffice-hide', shouldHide))
+
+						const versionMessage = data.version ? (' (' + t(OCA.Onlyoffice.AppName, 'version') + ' ' + data.version + ')') : ''
+
+						if (data.error) {
+							OCP.Toast.error(t(OCA.Onlyoffice.AppName, 'Error when trying to connect') + ' (' + data.error + ')' + versionMessage)
 						} else {
-							if (response.secret !== null) {
+							if (data.secret !== null) {
 								OCP.Toast.success(t(OCA.Onlyoffice.AppName, 'Server settings have been successfully updated') + versionMessage)
 							} else {
 								spawnDialog(defineAsyncComponent(() => import('./views/EmptyJwtInfoDialog.vue')))
 							}
 						}
 					} else {
-						$('.section-onlyoffice-common, .section-onlyoffice-templates, .section-onlyoffice-watermark').addClass('onlyoffice-hide')
+						const hideSections = document.querySelectorAll('.section-onlyoffice-common, .section-onlyoffice-templates, .section-onlyoffice-watermark')
+						hideSections.forEach(el => el.classList.add('onlyoffice-hide'))
 					}
-				},
-			})
+				})
+				.catch((error) => {
+					const section = document.querySelector('.section-onlyoffice')
+					if (section) section.classList.remove('icon-loading')
+					OCP.Toast.error(error.message || t(OCA.Onlyoffice.AppName, 'Failed to save settings'))
+				})
 		})
+	}
 
-		$('#onlyofficeSave').click(function() {
-			$('.section-onlyoffice').addClass('icon-loading')
+	const commonSaveButton = document.getElementById('onlyofficeCommonSave')
+	if (commonSaveButton) {
+		commonSaveButton.addEventListener('click', function() {
+			const section = document.querySelector('.section-onlyoffice')
+			if (section) section.classList.add('icon-loading')
 
 			const defFormats = {}
-			$('input[id^="onlyofficeDefFormat"]').each(function() {
-				defFormats[this.name] = this.checked
+			document.querySelectorAll('input[id^="onlyofficeDefFormat"]').forEach(function(input) {
+				defFormats[input.name] = input.checked
 			})
 
 			const editFormats = {}
-			$('input[id^="onlyofficeEditFormat"]').each(function() {
-				editFormats[this.name] = this.checked
+			document.querySelectorAll('input[id^="onlyofficeEditFormat"]').forEach(function(input) {
+				editFormats[input.name] = input.checked
 			})
 
-			const sameTab = $('#onlyofficeSameTab').is(':checked')
-			const enableSharing = $('#onlyofficeEnableSharing').is(':checked')
-			const preview = $('#onlyofficePreview').is(':checked')
-			const advanced = $('#onlyofficeAdvanced').is(':checked')
-			const cronChecker = $('#onlyofficeCronChecker').is(':checked')
-			const emailNotifications = $('#onlyofficeEmailNotifications').is(':checked')
-			const versionHistory = $('#onlyofficeVersionHistory').is(':checked')
+			const sameTab = document.getElementById('onlyofficeSameTab')?.checked || false
+			const enableSharing = document.getElementById('onlyofficeEnableSharing')?.checked || false
+			const preview = document.getElementById('onlyofficePreview')?.checked || false
+			const advanced = document.getElementById('onlyofficeAdvanced')?.checked || false
+			const cronChecker = document.getElementById('onlyofficeCronChecker')?.checked || false
+			const emailNotifications = document.getElementById('onlyofficeEmailNotifications')?.checked || false
+			const versionHistory = document.getElementById('onlyofficeVersionHistory')?.checked || false
 
-			const limitGroupsString = $('#onlyofficeGroups').prop('checked') ? $('#onlyofficeLimitGroups').val() : ''
+			const groupsCheckbox = document.getElementById('onlyofficeGroups')
+			const limitGroupsElement = document.getElementById('onlyofficeLimitGroups')
+			const limitGroupsString = (groupsCheckbox?.checked && limitGroupsElement) ? limitGroupsElement.value : ''
 			const limitGroups = limitGroupsString ? limitGroupsString.split('|') : []
 
-			const chat = $('#onlyofficeChat').is(':checked')
-			const compactHeader = $('#onlyofficeCompactHeader').is(':checked')
-			const feedback = $('#onlyofficeFeedback').is(':checked')
-			const forcesave = $('#onlyofficeForcesave').is(':checked')
-			const liveViewOnShare = $('#onlyofficeLiveViewOnShare').is(':checked')
-			const help = $('#onlyofficeHelp').is(':checked')
-			const reviewDisplay = $("input[type='radio'][name='reviewDisplay']:checked").attr('id').replace('onlyofficeReviewDisplay_', '')
-			const theme = $("input[type='radio'][name='theme']:checked").attr('id').replace('onlyofficeTheme_', '')
-			const unknownAuthor = $('#onlyofficeUnknownAuthor').val().trim()
+			const chat = document.getElementById('onlyofficeChat')?.checked || false
+			const compactHeader = document.getElementById('onlyofficeCompactHeader')?.checked || false
+			const feedback = document.getElementById('onlyofficeFeedback')?.checked || false
+			const forcesave = document.getElementById('onlyofficeForcesave')?.checked || false
+			const liveViewOnShare = document.getElementById('onlyofficeLiveViewOnShare')?.checked || false
+			const help = document.getElementById('onlyofficeHelp')?.checked || false
+			const reviewDisplay = document.querySelector("input[type='radio'][name='reviewDisplay']:checked")?.id.replace('onlyofficeReviewDisplay_', '') || ''
+			const theme = document.querySelector("input[type='radio'][name='theme']:checked")?.id.replace('onlyofficeTheme_', '') || ''
+			const unknownAuthorInput = document.getElementById('onlyofficeUnknownAuthor')
+			const unknownAuthor = unknownAuthorInput ? unknownAuthorInput.value.trim() : ''
 
-			$.ajax({
-				method: 'PUT',
-				url: OC.generateUrl('apps/' + OCA.Onlyoffice.AppName + '/ajax/settings/common'),
-				data: {
-					defFormats,
-					editFormats,
-					sameTab,
-					enableSharing,
-					preview,
-					advanced,
-					cronChecker,
-					emailNotifications,
-					versionHistory,
-					limitGroups,
-					chat,
-					compactHeader,
-					feedback,
-					forcesave,
-					liveViewOnShare,
-					help,
-					reviewDisplay,
-					theme,
-					unknownAuthor,
-				},
-				success: function onSuccess(response) {
-					$('.section-onlyoffice').removeClass('icon-loading')
-					if (response) {
-						OCP.Toast.success(t(OCA.Onlyoffice.AppName, 'Common settings have been successfully updated'))
-					}
-				},
+			axios.put(OC.generateUrl('apps/' + OCA.Onlyoffice.AppName + '/ajax/settings/common'), {
+				defFormats,
+				editFormats,
+				sameTab,
+				enableSharing,
+				preview,
+				advanced,
+				cronChecker,
+				emailNotifications,
+				versionHistory,
+				limitGroups,
+				chat,
+				compactHeader,
+				feedback,
+				forcesave,
+				liveViewOnShare,
+				help,
+				reviewDisplay,
+				theme,
+				unknownAuthor,
+			})
+			.then((response) => {
+				const section = document.querySelector('.section-onlyoffice')
+				if (section) section.classList.remove('icon-loading')
+				if (response.data) {
+					OCP.Toast.success(t(OCA.Onlyoffice.AppName, 'Common settings have been successfully updated'))
+				}
+			})
+			.catch((error) => {
+				const section = document.querySelector('.section-onlyoffice')
+				if (section) section.classList.remove('icon-loading')
+				OCP.Toast.error(error.message || t(OCA.Onlyoffice.AppName, 'Failed to save settings'))
 			})
 		})
+	}
 
-		$('#onlyofficeSecuritySave').click(function() {
-			$('.section-onlyoffice').addClass('icon-loading')
+	const securitySaveButton = document.getElementById('onlyofficeSecuritySave')
+	if (securitySaveButton) {
+		securitySaveButton.addEventListener('click', function() {
+			const section = document.querySelector('.section-onlyoffice')
+			if (section) section.classList.add('icon-loading')
 
-			const plugins = $('#onlyofficePlugins').is(':checked')
-			const macros = $('#onlyofficeMacros').is(':checked')
-			const protection = $("input[type='radio'][name='protection']:checked").attr('id').replace('onlyofficeProtection_', '')
+			const plugins = document.getElementById('onlyofficePlugins')?.checked || false
+			const macros = document.getElementById('onlyofficeMacros')?.checked || false
+			const protection = document.querySelector("input[type='radio'][name='protection']:checked")?.id.replace('onlyofficeProtection_', '') || ''
 
 			const watermarkSettings = {
-				enabled: $('#onlyofficeWatermark_enabled').is(':checked'),
+				enabled: document.getElementById('onlyofficeWatermark_enabled')?.checked || false,
 			}
 			if (watermarkSettings.enabled) {
-				watermarkSettings.text = ($('#onlyofficeWatermark_text').val() || '').trim()
+				const watermarkTextInput = document.getElementById('onlyofficeWatermark_text')
+				watermarkSettings.text = watermarkTextInput ? watermarkTextInput.value.trim() : ''
 
 				const watermarkLabels = [
 					'allGroups',
@@ -320,50 +413,67 @@ import { defineAsyncComponent } from 'vue'
 					'shareAll',
 					'shareRead',
 				]
-				$.each(watermarkLabels, function(i, watermarkLabel) {
-					watermarkSettings[watermarkLabel] = $('#onlyofficeWatermark_' + watermarkLabel).is(':checked')
+				watermarkLabels.forEach((watermarkLabel) => {
+					const checkbox = document.getElementById('onlyofficeWatermark_' + watermarkLabel)
+					watermarkSettings[watermarkLabel] = checkbox ? checkbox.checked : false
 				})
 
-				$.each(watermarkGroupLists.concat(watermarkTagLists), function(i, watermarkList) {
-					const list = $('#onlyofficeWatermark_' + watermarkList).is(':checked') ? $('#onlyofficeWatermark_' + watermarkList + 'List').val() : ''
+				watermarkGroupLists.concat(watermarkTagLists).forEach((watermarkList) => {
+					const checkbox = document.getElementById('onlyofficeWatermark_' + watermarkList)
+					const listElement = document.getElementById('onlyofficeWatermark_' + watermarkList + 'List')
+					const list = (checkbox?.checked && listElement) ? listElement.value : ''
 					watermarkSettings[watermarkList + 'List'] = list ? list.split('|') : []
 				})
 			}
 
-			$.ajax({
-				method: 'PUT',
-				url: OC.generateUrl('apps/' + OCA.Onlyoffice.AppName + '/ajax/settings/security'),
-				data: {
-					watermarks: watermarkSettings,
-					plugins,
-					macros,
-					protection,
-				},
-				success: function onSuccess(response) {
-					$('.section-onlyoffice').removeClass('icon-loading')
-					if (response) {
-						OCP.Toast.success(t(OCA.Onlyoffice.AppName, 'Security settings have been successfully updated'))
-					}
-				},
+			axios.put(OC.generateUrl('apps/' + OCA.Onlyoffice.AppName + '/ajax/settings/security'), {
+				watermarks: watermarkSettings,
+				plugins,
+				macros,
+				protection,
+			})
+			.then((response) => {
+				const section = document.querySelector('.section-onlyoffice')
+				if (section) section.classList.remove('icon-loading')
+				if (response.data) {
+					OCP.Toast.success(t(OCA.Onlyoffice.AppName, 'Security settings have been successfully updated'))
+				}
+			})
+			.catch((error) => {
+				const section = document.querySelector('.section-onlyoffice')
+				if (section) section.classList.remove('icon-loading')
+				OCP.Toast.error(error.message || t(OCA.Onlyoffice.AppName, 'Failed to save settings'))
 			})
 		})
+	}
 
-		$('.section-onlyoffice-addr input').keypress(function(e) {
+	document.querySelectorAll('.section-onlyoffice-addr input').forEach((input) => {
+		input.addEventListener('keypress', function(e) {
 			const code = e.keyCode || e.which
 			if (code === 13) {
-				$('#onlyofficeAddrSave').click()
+				const addrSaveButton = document.getElementById('onlyofficeAddrSave')
+				if (addrSaveButton) addrSaveButton.click()
 			}
 		})
+	})
 
-		$('#onlyofficeSecret-show').click(function() {
-			if ($('#onlyofficeSecret').attr('type') === 'password') {
-				$('#onlyofficeSecret').attr('type', 'text')
-			} else {
-				$('#onlyofficeSecret').attr('type', 'password')
+	const secretShowButton = document.getElementById('onlyofficeSecret-show')
+	if (secretShowButton) {
+		secretShowButton.addEventListener('click', function() {
+			const secretInput = document.getElementById('onlyofficeSecret')
+			if (secretInput) {
+				if (secretInput.type === 'password') {
+					secretInput.type = 'text'
+				} else {
+					secretInput.type = 'password'
+				}
 			}
 		})
+	}
 
-		$('#onlyofficeClearVersionHistory').click(function() {
+	const clearVersionHistoryButton = document.getElementById('onlyofficeClearVersionHistory')
+	if (clearVersionHistoryButton) {
+		clearVersionHistoryButton.addEventListener('click', function() {
 			OC.dialogs.confirm(
 				t(OCA.Onlyoffice.AppName, 'Are you sure you want to clear metadata?'),
 				t(OCA.Onlyoffice.AppName, 'Confirm metadata removal'),
@@ -372,32 +482,42 @@ import { defineAsyncComponent } from 'vue'
 						return
 					}
 
-					$('.section-onlyoffice').addClass('icon-loading')
+					const section = document.querySelector('.section-onlyoffice')
+					if (section) section.classList.add('icon-loading')
 
-					$.ajax({
-						method: 'DELETE',
-						url: OC.generateUrl('apps/' + OCA.Onlyoffice.AppName + '/ajax/settings/history'),
-						success: function onSuccess(response) {
-							$('.section-onlyoffice').removeClass('icon-loading')
-							if (response) {
+					axios.delete(OC.generateUrl('apps/' + OCA.Onlyoffice.AppName + '/ajax/settings/history'))
+						.then((response) => {
+							const section = document.querySelector('.section-onlyoffice')
+							if (section) section.classList.remove('icon-loading')
+							if (response.data) {
 								OCP.Toast.success(t(OCA.Onlyoffice.AppName, 'All history successfully deleted'))
 							}
 						},
+					)
+					.catch((error) => {
+						const section = document.querySelector('.section-onlyoffice')
+						if (section) section.classList.remove('icon-loading')
+						OCP.Toast.error(error.message || t(OCA.Onlyoffice.AppName, 'Failed to clear history'))
 					})
 				},
 			)
 		})
+	}
 
-		$('#onlyofficeAddTemplate').change(function() {
+	const addTemplateInput = document.getElementById('onlyofficeAddTemplate')
+	if (addTemplateInput) {
+		addTemplateInput.addEventListener('change', function() {
 			const file = this.files[0]
 			const data = new FormData()
 
 			data.append('file', file)
 
-			$('.section-onlyoffice').addClass('icon-loading')
+			const section = document.querySelector('.section-onlyoffice')
+			if (section) section.classList.add('icon-loading')
 			OCA.Onlyoffice.AddTemplate(file, (template, error) => {
 
-				$('.section-onlyoffice').removeClass('icon-loading')
+				const section = document.querySelector('.section-onlyoffice')
+				if (section) section.classList.remove('icon-loading')
 				const message = error
 					? t(OCA.Onlyoffice.AppName, 'Error') + ': ' + error
 					: t(OCA.Onlyoffice.AppName, 'Template successfully added')
@@ -413,14 +533,20 @@ import { defineAsyncComponent } from 'vue'
 				OCP.Toast.success(message)
 			})
 		})
+	}
 
-		$(document).on('click', '.onlyoffice-template-delete', function(event) {
-			const item = $(event.target).parents('.onlyoffice-template-item')
-			const templateId = $(item).attr('data-id')
+	document.addEventListener('click', function(event) {
+		if (event.target.classList.contains('onlyoffice-template-delete')) {
+			const item = event.target.closest('.onlyoffice-template-item')
+			const templateId = item ? item.getAttribute('data-id') : null
 
-			$('.section-onlyoffice').addClass('icon-loading')
+			if (!templateId) return
+
+			const section = document.querySelector('.section-onlyoffice')
+			if (section) section.classList.add('icon-loading')
 			OCA.Onlyoffice.DeleteTemplate(templateId, (response) => {
-				$('.section-onlyoffice').removeClass('icon-loading')
+				const section = document.querySelector('.section-onlyoffice')
+				if (section) section.classList.remove('icon-loading')
 
 				const message = response.error
 					? t(OCA.Onlyoffice.AppName, 'Error') + ': ' + response.error
@@ -430,14 +556,18 @@ import { defineAsyncComponent } from 'vue'
 					return
 				}
 
-				$(item).detach()
+				if (item && item.parentNode) {
+					item.parentNode.removeChild(item)
+				}
 				OCP.Toast.success(message)
 			})
-		})
+		}
 
-		$(document).on('click', '.onlyoffice-template-item p', function(event) {
-			const item = $(event.target).parents('.onlyoffice-template-item')
-			const templateId = $(item).attr('data-id')
+		if (event.target.matches('.onlyoffice-template-item p')) {
+			const item = event.target.closest('.onlyoffice-template-item')
+			const templateId = item ? item.getAttribute('data-id') : null
+
+			if (!templateId) return
 
 			const url = OC.generateUrl('/apps/' + OCA.Onlyoffice.AppName + '/{fileId}?template={template}',
 				{
@@ -446,11 +576,13 @@ import { defineAsyncComponent } from 'vue'
 				})
 
 			window.open(url)
-		})
+		}
 
-		$(document).on('click', '.onlyoffice-template-download', function(event) {
-			const item = $(event.target).parents('.onlyoffice-template-item')
-			const templateId = $(item).attr('data-id')
+		if (event.target.classList.contains('onlyoffice-template-download')) {
+			const item = event.target.closest('.onlyoffice-template-item')
+			const templateId = item ? item.getAttribute('data-id') : null
+
+			if (!templateId) return
 
 			const downloadLink = OC.generateUrl('apps/' + OCA.Onlyoffice.AppName + '/downloadas?fileId={fileId}&template={template}', {
 				fileId: templateId,
@@ -458,7 +590,8 @@ import { defineAsyncComponent } from 'vue'
 			})
 
 			location.href = downloadLink
-		})
+		}
+	})
 
 		const sameTabCheckbox = document.getElementById('onlyofficeSameTab')
 		const sharingBlock = document.getElementById('onlyofficeEnableSharingBlock')
@@ -471,4 +604,4 @@ import { defineAsyncComponent } from 'vue'
 		}
 	})
 
-})(jQuery, OC)
+})(OC)

--- a/src/share.js
+++ b/src/share.js
@@ -29,15 +29,15 @@
 /* eslint-disable import/no-webpack-loader-syntax */
 /* eslint-disable import/no-unresolved */
 
-/* global _, jQuery */
+/* global _ */
 
-import AppDarkSvg from '!!raw-loader!../img/app-dark.svg';
+import AppDarkSvg from '!!raw-loader!../img/app-dark.svg'
+import axios from '@nextcloud/axios'
 
 /**
- * @param {object} $ JQueryStatic object
  * @param {object} OC Nextcloud OCA object
  */
-(function($, OC) {
+(function(OC) {
 
 	OCA.Onlyoffice = _.extend({
 		AppName: 'onlyoffice',
@@ -86,11 +86,6 @@ import AppDarkSvg from '!!raw-loader!../img/app-dark.svg';
 					|| format.modifyFilter)) {
 					canDisplay = true
 
-					if (($('#sharing').hasClass('active') || $('#tab-button-sharing').hasClass('active'))
-						&& tabcontext.fileInfo
-						&& tabcontext.fileInfo.id === fileInfo.id) {
-						this.update(fileInfo)
-					}
 				}
 			}
 
@@ -99,7 +94,7 @@ import AppDarkSvg from '!!raw-loader!../img/app-dark.svg';
 	})
 
 	const advancedContext = function() {
-		let $el = null
+		let el = null
 
 		let format = null
 		let fileInfo = null
@@ -109,13 +104,18 @@ import AppDarkSvg from '!!raw-loader!../img/app-dark.svg';
 		let templateItem = null
 
 		const getContainer = function() {
-			return $el.find('.onlyoffice-share-container')
+			return el.querySelector('.onlyoffice-share-container')
 		}
 
 		const getTemplate = function(callback) {
-			if ($el.find('.onlyoffice-share-container').length === 0) {
-				$('<ul>', { class: 'onlyoffice-share-container' }).appendTo($el)
-				$('<div>').html(t(OCA.Onlyoffice.AppName, 'Provide advanced document permissions using ONLYOFFICE Docs')).prependTo($el)
+			if (!el.querySelector('.onlyoffice-share-container')) {
+				const ul = document.createElement('ul')
+				ul.className = 'onlyoffice-share-container'
+				el.appendChild(ul)
+
+				const div = document.createElement('div')
+				div.textContent = t(OCA.Onlyoffice.AppName, 'Provide advanced document permissions using ONLYOFFICE Docs')
+				el.insertBefore(div, el.firstChild)
 			}
 
 			if (templateItem) {
@@ -123,9 +123,11 @@ import AppDarkSvg from '!!raw-loader!../img/app-dark.svg';
 				return
 			}
 
-			$.get(OC.filePath(OCA.Onlyoffice.AppName, 'templates', 'share.html'),
-				function(tmpl) {
-					templateItem = $(tmpl)
+			axios.get(OC.filePath(OCA.Onlyoffice.AppName, 'templates', 'share.html'))
+				.then((response) => {
+					const tempDiv = document.createElement('div')
+					tempDiv.innerHTML = response.data
+					templateItem = tempDiv.firstElementChild
 
 					callback()
 				})
@@ -134,10 +136,10 @@ import AppDarkSvg from '!!raw-loader!../img/app-dark.svg';
 		const render = function() {
 			getTemplate(() => {
 				collection.forEach(extra => {
-					const itemNode = templateItem.clone()
-					const descNode = itemNode.find('span')
-					const avatar = itemNode.find('img')
-					const actionButton = itemNode.find('#onlyoffice-share-action')
+					const itemNode = templateItem.cloneNode(true)
+					const descNode = itemNode.querySelector('span')
+					const avatar = itemNode.querySelector('img')
+					const actionButton = itemNode.querySelector('#onlyoffice-share-action')
 
 					let avatarSrc = '/index.php/avatar/' + extra.shareWith + '/32?v=0'
 					let label = extra.shareWithName
@@ -154,20 +156,24 @@ import AppDarkSvg from '!!raw-loader!../img/app-dark.svg';
 					if (extra.type === OC.Share.SHARE_TYPE_LINK) {
 						label = t(OCA.Onlyoffice.AppName, 'Share link')
 
-						const avatarWrapper = itemNode.find('.avatardiv')
-						avatarWrapper.addClass('onlyoffice-share-link-avatar')
+						const avatarWrapper = itemNode.querySelector('.avatardiv')
+						if (avatarWrapper) {
+							avatarWrapper.classList.add('onlyoffice-share-link-avatar')
+						}
 
 						avatarSrc = '/core/img/actions/public.svg'
 					}
 
-					actionButton.click(onClickPermissionMenu)
+					if (actionButton) {
+						actionButton.addEventListener('click', onClickPermissionMenu)
+					}
 
-					avatar[0].src = avatarSrc
-					descNode[0].innerText = label
+					if (avatar) avatar.src = avatarSrc
+					if (descNode) descNode.textContent = label
 
-					itemNode[0].id = extra.share_id
+					itemNode.id = extra.share_id
 
-					getContainer().append(itemNode)
+					getContainer().appendChild(itemNode)
 				})
 			})
 		}
@@ -232,7 +238,7 @@ import AppDarkSvg from '!!raw-loader!../img/app-dark.svg';
 			}
 			window.addEventListener('click', listenOuterClicks)
 
-			const shareNode = $(e.target).closest('.onlyoffice-share-item')[0]
+			const shareNode = e.target.closest('.onlyoffice-share-item')
 			const shareId = shareNode.id
 
 			if (permissionsMenu.isOpen()) {
@@ -246,7 +252,9 @@ import AppDarkSvg from '!!raw-loader!../img/app-dark.svg';
 
 			const attributes = getPermissionAttributes(extra)
 
-			permissionsMenu.open(extra.share_id, attributes, $(e.target).position())
+			const targetElement = e.target
+			const rect = targetElement.getBoundingClientRect()
+			permissionsMenu.open(extra.share_id, attributes, { top: rect.top, left: rect.left })
 		}
 
 		const getCustomEvents = function() {
@@ -255,18 +263,21 @@ import AppDarkSvg from '!!raw-loader!../img/app-dark.svg';
 			return {
 				on() {
 					if (!init) {
-						$('#content').on('click', function(e) {
-							const target = $(e.target)[0]
-							if (!permissionsMenu
-								|| !permissionsMenu.isOpen()
-								|| target.id === 'onlyoffice-share-action'
-								|| target.className === 'onlyoffice-share-label'
-								|| target.closest('.onlyoffice-share-action')) {
-								return
-							}
+						const content = document.getElementById('content')
+						if (content) {
+							content.addEventListener('click', function(e) {
+								const target = e.target
+								if (!permissionsMenu
+									|| !permissionsMenu.isOpen()
+									|| target.id === 'onlyoffice-share-action'
+									|| target.className === 'onlyoffice-share-label'
+									|| target.closest('.onlyoffice-share-action')) {
+									return
+								}
 
-							permissionsMenu.close()
-						})
+								permissionsMenu.close()
+							})
+						}
 
 						init = true
 					}
@@ -319,56 +330,62 @@ import AppDarkSvg from '!!raw-loader!../img/app-dark.svg';
 		}
 
 		const getPermissionMenu = function() {
-			const popup = $('<div>', {
-				class: 'popovermenu onlyoffice-share-popup',
-				id: 'onlyoffice-share-popup-menu',
-			}).append($('<ul>'), {
-				id: -1,
-			})
+			const popup = document.createElement('div')
+			popup.className = 'popovermenu onlyoffice-share-popup'
+			popup.id = 'onlyoffice-share-popup-menu'
+
+			const ul = document.createElement('ul')
+			ul.id = '-1'
+			popup.appendChild(ul)
 
 			const appendItem = function(checked, extra, name) {
-				const item = $('<li>').append($('<span>', {
-					class: 'onlyoffice-share-action',
-				}).append($('<input>', {
-					id: 'extra-' + extra,
-					type: 'checkbox',
-					class: 'checkbox action-checkbox__checkbox focusable',
-					checked,
-				})).append($('<label>', {
-					for: 'extra-' + extra,
-					text: name,
-					class: 'onlyoffice-share-label',
-				})))
+				const item = document.createElement('li')
+				const span = document.createElement('span')
+				span.className = 'onlyoffice-share-action'
 
-				const input = item.find('input')
-				input.click(onClickSetPermissions)
+				const input = document.createElement('input')
+				input.id = 'extra-' + extra
+				input.type = 'checkbox'
+				input.className = 'checkbox action-checkbox__checkbox focusable'
+				input.checked = checked
+				input.addEventListener('click', onClickSetPermissions)
 
-				popup.find('ul').append(item)
+				const label = document.createElement('label')
+				label.htmlFor = 'extra-' + extra
+				label.textContent = name
+				label.className = 'onlyoffice-share-label'
+
+				span.appendChild(input)
+				span.appendChild(label)
+				item.appendChild(span)
+
+				popup.querySelector('ul').appendChild(item)
 			}
 
 			const removeItems = function() {
-				const items = popup.find('li')
-				if (items) {
-					items.remove()
-				}
+				const items = popup.querySelectorAll('li')
+				items.forEach(item => item.remove())
 			}
 
 			const setTargetId = function(id) {
-				popup.find('ul').attr('id', id)
+				const ulElement = popup.querySelector('ul')
+				if (ulElement) {
+					ulElement.id = id
+				}
 			}
 
-			$el.append(popup)
+			el.appendChild(popup)
 
 			return {
 				isOpen() {
-					return popup.is(':visible')
+					return popup.style.display !== 'none' && popup.style.display !== ''
 				},
 
 				open(id, attributes, position) {
 					removeItems()
 
 					if (position) {
-						popup.css({ top: position.top })
+						popup.style.top = position.top + 'px'
 					}
 
 					attributes.forEach(attr => {
@@ -376,14 +393,14 @@ import AppDarkSvg from '!!raw-loader!../img/app-dark.svg';
 					})
 
 					setTargetId(id)
-					popup.show()
+					popup.style.display = 'block'
 				},
 
 				close() {
 					removeItems()
 
 					setTargetId(-1)
-					popup.hide()
+					popup.style.display = 'none'
 					window.removeEventListener('click', listenOuterClicks)
 				},
 
@@ -396,23 +413,27 @@ import AppDarkSvg from '!!raw-loader!../img/app-dark.svg';
 				},
 
 				block(value) {
-					popup.find('input').prop('disabled', value)
+					const inputs = popup.querySelectorAll('input')
+					inputs.forEach(input => {
+						input.disabled = value
+					})
 				},
 
 				getValues() {
 					const values = []
 
-					const items = popup.find('input')
-					for (let i = 0; i < items.length; i++) {
-						const extra = items[i].id.split('extra-')[1]
-						values[extra] = items[i].checked
-					}
+					const inputs = popup.querySelectorAll('input')
+					inputs.forEach(input => {
+						const extra = input.id.split('extra-')[1]
+						values[extra] = input.checked
+					})
 
 					return values
 				},
 
 				getTargetId() {
-					return popup.find('ul').attr('id')
+					const ulElement = popup.querySelector('ul')
+					return ulElement ? ulElement.id : null
 				},
 			}
 		}
@@ -423,7 +444,7 @@ import AppDarkSvg from '!!raw-loader!../img/app-dark.svg';
 			},
 
 			init(_el, _fileInfo) {
-				$el = $(_el)
+				el = _el
 
 				getTemplate(() => {
 					this.update(_fileInfo)
@@ -436,7 +457,12 @@ import AppDarkSvg from '!!raw-loader!../img/app-dark.svg';
 					customEvents.on()
 				}
 
-				getContainer().children().remove()
+				const container = getContainer()
+				if (container) {
+					while (container.firstChild) {
+						container.removeChild(container.firstChild)
+					}
+				}
 
 				fileInfo = _fileInfo
 
@@ -451,7 +477,7 @@ import AppDarkSvg from '!!raw-loader!../img/app-dark.svg';
 			},
 
 			clear() {
-				$el = null
+				el = null
 				format = null
 				fileInfo = null
 				collection = null
@@ -461,34 +487,26 @@ import AppDarkSvg from '!!raw-loader!../img/app-dark.svg';
 	}
 
 	OCA.Onlyoffice.GetShares = function(fileId, callback) {
-		$.ajax({
-			url: OC.linkToOCS('apps/' + OCA.Onlyoffice.AppName + '/api/v1/shares', 2) + fileId + '?format=json',
-			success: function onSuccess(response) {
-				callback(response.ocs.data)
-			},
-		})
+		axios.get(OC.linkToOCS('apps/' + OCA.Onlyoffice.AppName + '/api/v1/shares', 2) + fileId + '?format=json')
+			.then((response) => {
+				callback(response.data.ocs.data)
+			})
 	}
 
 	OCA.Onlyoffice.SetShares = function(id, shareId, fileId, permissions, callback) {
-		const data = {
+		axios.put(OC.linkToOCS('apps/' + OCA.Onlyoffice.AppName + '/api/v1', 2) + 'shares?format=json', {
 			extraId: id,
 			shareId,
 			fileId,
 			permissions,
-		}
-
-		$.ajax({
-			method: 'PUT',
-			url: OC.linkToOCS('apps/' + OCA.Onlyoffice.AppName + '/api/v1', 2) + 'shares?format=json',
-			data,
-			success: function onSuccess(response) {
-				callback(response.ocs.data)
-			},
 		})
+			.then((response) => {
+				callback(response.data.ocs.data)
+			})
 	}
 
 	if (OCA.Files.Sidebar && OCA.Files.Sidebar.registerTab) {
 		OCA.Files.Sidebar.registerTab(advancedTab)
 	}
 
-})(jQuery, OC)
+})(OC)

--- a/src/template.js
+++ b/src/template.js
@@ -26,13 +26,14 @@
  *
  */
 
-/* global _, jQuery */
+/* global _ */
+
+import axios from '@nextcloud/axios'
 
 /**
- * @param {object} $ JQueryStatic object
  * @param {object} OC Nextcloud OCA object
  */
-(function($, OC) {
+(function(OC) {
 
 	OCA.Onlyoffice = _.extend({
 		AppName: 'onlyoffice',
@@ -41,28 +42,32 @@
 
 	OCA.Onlyoffice.OpenTemplatePicker = function(name, extension, type) {
 
-		$('#onlyoffice-template-picker').remove()
+		const existingPicker = document.getElementById('onlyoffice-template-picker')
+		if (existingPicker) {
+			existingPicker.remove()
+		}
 
-		$.get(OC.filePath(OCA.Onlyoffice.AppName, 'templates', 'templatePicker.html'),
-			function(tmpl) {
-				const $tmpl = $(tmpl)
-				const dialog = $tmpl.octemplate({
+		axios.get(OC.filePath(OCA.Onlyoffice.AppName, 'templates', 'templatePicker.html'))
+			.then((response) => {
+				const tempDiv = document.createElement('div')
+				tempDiv.innerHTML = response.data
+				const dialog = window.$(tempDiv.firstElementChild).octemplate({
 					dialog_name: 'onlyoffice-template-picker',
 					dialog_title: t(OCA.Onlyoffice.AppName, 'Select template'),
 				})
 
 				OCA.Onlyoffice.AttachTemplates(dialog, type)
 
-				$('body').append(dialog)
+				document.body.appendChild(dialog[0])
 
-				$('#onlyoffice-template-picker').ocdialog({
+				window.$('#onlyoffice-template-picker').ocdialog({
 					closeOnEscape: true,
 					modal: true,
 					buttons: [{
 						text: t('core', 'Cancel'),
 						classes: 'cancel',
 						click() {
-							$(this).ocdialog('close')
+							window.$(this).ocdialog('close')
 						},
 					}, {
 						text: t(OCA.Onlyoffice.AppName, 'Create'),
@@ -71,7 +76,7 @@
 							const templateId = this.dataset.templateId
 							const fileList = OCA.Files.App.fileList
 							OCA.Onlyoffice.CreateFile(name + extension, fileList, templateId)
-							$(this).ocdialog('close')
+							window.$(this).ocdialog('close')
 						},
 					}],
 				})
@@ -83,18 +88,18 @@
 			return
 		}
 
-		$.get(OC.generateUrl('apps/' + OCA.Onlyoffice.AppName + '/ajax/template'),
-			function onSuccess(response) {
-				if (response.error) {
-					OC.Notification.show(response.error, {
+		axios.get(OC.generateUrl('apps/' + OCA.Onlyoffice.AppName + '/ajax/template'))
+			.then((response) => {
+				const data = response.data
+				if (data.error) {
+					OC.Notification.show(data.error, {
 						type: 'error',
 						timeout: 3,
 					})
 					return
 				}
 
-				OCA.Onlyoffice.templates = response
-
+				OCA.Onlyoffice.templates = data
 			})
 	}
 
@@ -102,36 +107,31 @@
 		const data = new FormData()
 		data.append('file', file)
 
-		$.ajax({
-			method: 'POST',
-			url: OC.generateUrl('apps/' + OCA.Onlyoffice.AppName + '/ajax/template'),
-			data,
-			processData: false,
-			contentType: false,
-			success: function onSuccess(response) {
-				if (response.error) {
-					callback(null, response.error)
+		axios.post(OC.generateUrl('apps/' + OCA.Onlyoffice.AppName + '/ajax/template'), data)
+			.then((response) => {
+				const data = response.data
+				if (data.error) {
+					callback(null, data.error)
 					return
 				}
 
-				callback(response, null)
-			},
-		})
+				callback(data, null)
+			})
+			.catch((error) => {
+				callback(null, error.message || 'Failed to add template')
+			})
 	}
 
 	OCA.Onlyoffice.DeleteTemplate = function(templateId, callback) {
-		$.ajax({
-			method: 'DELETE',
-			url: OC.generateUrl('apps/' + OCA.Onlyoffice.AppName + '/ajax/template?templateId={templateId}',
-				{
-					templateId,
-				}),
-			success: function onSuccess(response) {
-				if (response) {
-					callback(response)
+		axios.delete(OC.generateUrl('apps/' + OCA.Onlyoffice.AppName + '/ajax/template?templateId={templateId}',
+			{
+				templateId,
+			}))
+			.then((response) => {
+				if (response.data) {
+					callback(response.data)
 				}
-			},
-		})
+			})
 	}
 
 	OCA.Onlyoffice.AttachTemplates = function(dialog, type) {
@@ -143,36 +143,71 @@
 			}
 			const item = emptyItem.cloneNode(true)
 
-			$(item.querySelector('label')).attr('for', 'template_picker-' + template.id)
-			item.querySelector('input').id = 'template_picker-' + template.id
-			item.querySelector('img').src = template.icon
-			item.querySelector('p').textContent = template.name
+			const label = item.querySelector('label')
+			if (label) {
+				label.setAttribute('for', 'template_picker-' + template.id)
+			}
+			const input = item.querySelector('input')
+			if (input) {
+				input.id = 'template_picker-' + template.id
+			}
+			const img = item.querySelector('img')
+			if (img) {
+				img.src = template.icon
+			}
+			const p = item.querySelector('p')
+			if (p) {
+				p.textContent = template.name
+			}
 			item.onclick = function() {
 				dialog[0].dataset.templateId = template.id
 			}
 			dialog[0].querySelector('.onlyoffice-template-container').appendChild(item)
 		})
 
-		$(emptyItem.querySelector('label')).attr('for', 'template_picker-0')
-		emptyItem.querySelector('input').id = 'template_picker-0'
-		emptyItem.querySelector('input').checked = true
-		emptyItem.querySelector('img').src = OC.generateUrl('/core/img/filetypes/x-office-' + type + '.svg')
-		emptyItem.querySelector('p').textContent = t(OCA.Onlyoffice.AppName, 'Empty')
+		const emptyLabel = emptyItem.querySelector('label')
+		if (emptyLabel) {
+			emptyLabel.setAttribute('for', 'template_picker-0')
+		}
+		const emptyInput = emptyItem.querySelector('input')
+		if (emptyInput) {
+			emptyInput.id = 'template_picker-0'
+			emptyInput.checked = true
+		}
+		const emptyImg = emptyItem.querySelector('img')
+		if (emptyImg) {
+			emptyImg.src = OC.generateUrl('/core/img/filetypes/x-office-' + type + '.svg')
+		}
+		const emptyP = emptyItem.querySelector('p')
+		if (emptyP) {
+			emptyP.textContent = t(OCA.Onlyoffice.AppName, 'Empty')
+		}
 		emptyItem.onclick = function() {
 			dialog[0].dataset.templateId = '0'
 		}
 	}
 
 	OCA.Onlyoffice.AttachItemTemplate = function(template) {
-		$.get(OC.filePath(OCA.Onlyoffice.AppName, 'templates', 'templateItem.html'),
-			function(item) {
-				item = $(item)
+		axios.get(OC.filePath(OCA.Onlyoffice.AppName, 'templates', 'templateItem.html'))
+			.then((response) => {
+				const tempDiv = document.createElement('div')
+				tempDiv.innerHTML = response.data
+				const item = tempDiv.firstElementChild
 
-				item.attr('data-id', template.id)
-				item.children('img').attr('src', template.icon)
-				item.children('p').text(template.name)
+				item.setAttribute('data-id', template.id)
+				const img = item.querySelector('img')
+				if (img) {
+					img.setAttribute('src', template.icon)
+				}
+				const p = item.querySelector('p')
+				if (p) {
+					p.textContent = template.name
+				}
 
-				$('.onlyoffice-template-container').append(item)
+				const container = document.querySelector('.onlyoffice-template-container')
+				if (container) {
+					container.appendChild(item)
+				}
 			})
 	}
 
@@ -184,4 +219,4 @@
 		return isExist
 	}
 
-})(jQuery, OC)
+})(OC)

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -26,8 +26,6 @@
  *
  */
 
-/* global $ */
-
 /**
  * @param {object} OCA Nextcloud OCA object
  */
@@ -86,12 +84,10 @@
 	if (OCA.Viewer) {
 		OCA.Onlyoffice.frameSelector = '#onlyofficeViewerFrame'
 
-		const mimes = $.map(OCA.Onlyoffice.setting.formats, function(format) {
-			if (format.def) {
-				return format.mime
-			}
-		})
-		mimes.flat()
+		const mimes = OCA.Onlyoffice.setting.formats
+			.filter(format => format.def)
+			.map(format => format.mime)
+			.flat()
 		OCA.Viewer.registerHandler({
 			id: OCA.Onlyoffice.AppName,
 			group: null,


### PR DESCRIPTION
This has gotten larger then expected, but is required to make the app work on latest server master

- Replace jquery usage https://github.com/nextcloud/server/pull/57648
- Use npm packages instead of deprecated private global methods (url generator, current user)
- Update @nextcloud/files to be compatible with the latest version

The app still has tons of old legacy code that is probably required for compatibility before Nextcloud 32. We could think about cleaning that up, but probably for now want to upstream this.