### PR TITLE
feat(smartpicker): wire NC Assistant Smart Picker bridge

### DIFF
--- a/lib/Controller/EditorController.php
+++ b/lib/Controller/EditorController.php
@@ -38,6 +38,7 @@ use OCA\Eurooffice\FileUtility;
 use OCA\Eurooffice\FileVersions;
 use OCA\Eurooffice\KeyManager;
 use OCA\Eurooffice\TemplateManager;
+use OCP\App\IAppManager;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http\ContentSecurityPolicy;
 use OCP\AppFramework\Http\DataDownloadResponse;
@@ -48,6 +49,7 @@ use OCP\AppFramework\Http\Attribute\NoCSRFRequired;
 use OCP\AppFramework\Http\Attribute\PublicPage;
 use OCP\AppFramework\Http\Template\PublicTemplateResponse;
 use OCP\AppFramework\Http\TemplateResponse;
+use OCP\AppFramework\Services\IInitialState;
 use OCP\Constants;
 use OCP\Files\File;
 use OCP\Files\IRootFolder;
@@ -89,7 +91,9 @@ class EditorController extends Controller {
         private readonly DocumentService $documentService,
         private readonly KeyManager $keyManager,
         private readonly ?IVersionManager $versionManager,
-        private readonly ?FolderManager $folderManager
+        private readonly ?FolderManager $folderManager,
+        private readonly IInitialState $initialState,
+        private readonly IAppManager $appManager,
     ) {
         parent::__construct($appName, $request);
     }
@@ -1347,6 +1351,11 @@ class EditorController extends Controller {
                 $response->setHeaderTitle($file->getName());
             }
         }
+
+        $this->initialState->provideInitialState(
+            'assistant-enabled',
+            $this->appManager->isEnabledForUser('assistant')
+        );
 
         \OCP\Util::addHeader("meta", ["name" => "apple-touch-fullscreen", "content" => "yes"]);
 

--- a/src/editor.js
+++ b/src/editor.js
@@ -141,9 +141,21 @@ import axios from '@nextcloud/axios'
 							onMakeActionLink: OCA.Eurooffice.onMakeActionLink,
 						}
 
-						if (config.editorConfig.tenant) {
-							config.events.onAppReady = function() {
+						config.events.onAppReady = function() {
+							if (config.editorConfig.tenant) {
 								OCA.Eurooffice.docEditor.showMessage(t(OCA.Eurooffice.AppName, 'You are using public demo Nextcloud Office server. Please do not store private sensitive data.'))
+							}
+							// Tell the editor whether the NC Assistant app is enabled.
+							// onAppReady can fire before assistant-main.mjs has finished
+							// initializing window.OCA.Assistant, so don't rely on that
+							// runtime presence — read the capability NC publishes
+							// synchronously instead. The actual openAssistantForm call
+							// happens only when the user clicks the menu entry, by which
+							// time the module has loaded.
+							const caps = (typeof OC === 'object' && OC.getCapabilities && OC.getCapabilities()) || {}
+							const assistantAvailable = !!(caps.assistant && caps.assistant.enabled)
+							if (typeof OCA.Eurooffice.docEditor.setAssistantAvailable === 'function') {
+								OCA.Eurooffice.docEditor.setAssistantAvailable(assistantAvailable)
 							}
 						}
 
@@ -160,6 +172,7 @@ import axios from '@nextcloud/axios'
 							config.events.onRequestReferenceSource = OCA.Eurooffice.onRequestReferenceSource
 							config.events.onMetaChange = OCA.Eurooffice.onMetaChange
 							config.events.onRequestRefreshFile = OCA.Eurooffice.onRequestRefreshFile
+							config.events.onRequestSmartPicker = OCA.Eurooffice.onRequestSmartPicker
 
 							if (OCA.Eurooffice.currentUser.uid) {
 								config.events.onRequestUsers = OCA.Eurooffice.onRequestUsers
@@ -382,6 +395,17 @@ import axios from '@nextcloud/axios'
 
 				OCA.Eurooffice.docEditor.insertImage(data)
 			})
+	}
+
+	OCA.Eurooffice.onRequestSmartPicker = function(event) {
+		// The web-apps Gateway delivers the user's current selection via
+		// event.data.selectedText so the NC Assistant can seed its input
+		// with the text the user wants to operate on.
+		const selectedText = event && event.data && event.data.selectedText ? event.data.selectedText : ''
+		window.parent.postMessage({
+			method: 'editorRequestSmartPicker',
+			param: { selectedText },
+		}, '*')
 	}
 
 	OCA.Eurooffice.onRequestMailMergeRecipients = function() {

--- a/src/editor.js
+++ b/src/editor.js
@@ -146,14 +146,11 @@ import axios from '@nextcloud/axios'
 								OCA.Eurooffice.docEditor.showMessage(t(OCA.Eurooffice.AppName, 'You are using public demo Nextcloud Office server. Please do not store private sensitive data.'))
 							}
 							// Tell the editor whether the NC Assistant app is enabled.
-							// onAppReady can fire before assistant-main.mjs has finished
-							// initializing window.OCA.Assistant, so don't rely on that
-							// runtime presence — read the capability NC publishes
-							// synchronously instead. The actual openAssistantForm call
-							// happens only when the user clicks the menu entry, by which
-							// time the module has loaded.
-							const caps = (typeof OC === 'object' && OC.getCapabilities && OC.getCapabilities()) || {}
-							const assistantAvailable = !!(caps.assistant && caps.assistant.enabled)
+							// The EditorController publishes this via initial state under
+							// the 'eurooffice' namespace so it works on every editor layout
+							// (including the inframe 'base' layout that doesn't run the
+							// Assistant app's own initial-state bootstrap).
+							const assistantAvailable = !!OCP?.InitialState?.loadState?.('eurooffice', 'assistant-enabled', false)
 							if (typeof OCA.Eurooffice.docEditor.setAssistantAvailable === 'function') {
 								OCA.Eurooffice.docEditor.setAssistantAvailable(assistantAvailable)
 							}
@@ -401,7 +398,7 @@ import axios from '@nextcloud/axios'
 		// The web-apps Gateway delivers the user's current selection via
 		// event.data.selectedText so the NC Assistant can seed its input
 		// with the text the user wants to operate on.
-		const selectedText = event && event.data && event.data.selectedText ? event.data.selectedText : ''
+		const selectedText = event?.data?.selectedText ?? ''
 		window.parent.postMessage({
 			method: 'editorRequestSmartPicker',
 			param: { selectedText },

--- a/src/listener.js
+++ b/src/listener.js
@@ -84,6 +84,50 @@
 		}
 	}
 
+	// Open the NC Assistant text-processing form seeded with the editor
+	// selection. We deliberately do NOT add an "Insert into editor" action
+	// button: writing the AI result back into the document strips formatting
+	// and produces low-quality replacements (markup is lost on plain-text
+	// paste). Until that round-trip preserves at least basic styling, the
+	// feature is intentionally read-only — the user copies the result from
+	// the modal manually. The modal's built-in close button dismisses it.
+	OCA.Eurooffice.onSmartPickerRequest = async function(selectedText) {
+		if (this.showSmartPicker) {
+			return
+		}
+		this.showSmartPicker = true
+
+		const openAssistantForm = window.OCA && window.OCA.Assistant && window.OCA.Assistant.openAssistantForm
+		try {
+			if (typeof openAssistantForm !== 'function') {
+				console.debug('NC Assistant app is not loaded; smart picker is unavailable')
+				return
+			}
+			// openAssistantForm maps a single `input` string to
+			// initInputs:{prompt: input} which only fits picker-style task
+			// types. Seed `inputs` directly so core:text2text:* (translate,
+			// summarize, rewrite, …) — which expects an `input` key — gets
+			// the user's selection too. Populate prompt/input/text so any
+			// task type's input field finds the seed already there.
+			const seedInputs = selectedText
+				? { prompt: selectedText, input: selectedText, text: selectedText }
+				: {}
+			await openAssistantForm({
+				appId: OCA.Eurooffice.AppName,
+				taskType: 'core:text2text',
+				inputs: seedInputs,
+				// false so the result renders inside the modal and the user can
+				// read / copy it. With true the modal would unmount the moment
+				// the task finishes.
+				closeOnResult: false,
+			})
+		} catch (e) {
+			console.debug('Smart Picker cancelled or failed:', e)
+		} finally {
+			this.showSmartPicker = false
+		}
+	}
+
 	OCA.Eurooffice.onRequestMailMergeRecipients = function(recipientMimes) {
 		const frame = document.querySelector(OCA.Eurooffice.frameSelector)
 		if (frame && frame.contentWindow) {
@@ -183,6 +227,9 @@
 			break
 		case 'editorRequestInsertImage':
 			OCA.Eurooffice.onRequestInsertImage(event.data.param)
+			break
+		case 'editorRequestSmartPicker':
+			OCA.Eurooffice.onSmartPickerRequest(event.data.param && event.data.param.selectedText)
 			break
 		case 'editorRequestMailMergeRecipients':
 			OCA.Eurooffice.onRequestMailMergeRecipients(event.data.param)

--- a/src/listener.js
+++ b/src/listener.js
@@ -97,7 +97,7 @@
 		}
 		this.showSmartPicker = true
 
-		const openAssistantForm = window.OCA && window.OCA.Assistant && window.OCA.Assistant.openAssistantForm
+		const openAssistantForm = window.OCA?.Assistant?.openAssistantForm
 		try {
 			if (typeof openAssistantForm !== 'function') {
 				console.debug('NC Assistant app is not loaded; smart picker is unavailable')
@@ -229,7 +229,7 @@
 			OCA.Eurooffice.onRequestInsertImage(event.data.param)
 			break
 		case 'editorRequestSmartPicker':
-			OCA.Eurooffice.onSmartPickerRequest(event.data.param && event.data.param.selectedText)
+			OCA.Eurooffice.onSmartPickerRequest(event.data.param?.selectedText)
 			break
 		case 'editorRequestMailMergeRecipients':
 			OCA.Eurooffice.onRequestMailMergeRecipients(event.data.param)


### PR DESCRIPTION


Adds the editor<->NC bridge needed for the toolbar's Smart Picker / Nextcloud Assistant button (registered on the OO web-apps side):

editor.js (runs inside the editor iframe):
- config.events.onRequestSmartPicker forwards the editor's postMessage payload to the host with the user's current selection
- onAppReady detects window.OCA.Assistant.openAssistantForm and calls docEditor.setSmartPickerEnabled so the toolbar entry grays out when the Assistant app is not loaded
- editorInsertLink / editorInsertPlainText expose Promise-wrapped hooks the host calls to insert the AI result back at the cursor

listener.js (runs in the NC parent window):
- onSmartPickerRequest opens window.OCA.Assistant.openAssistantForm with taskType core:text2text and the selected text seeded into prompt/input/text keys (covers chat/text2text/translate/summarize /rewrite); registers an 'Insert into editor' action button that routes the finished task's output back through the editor

<img width="1179" height="473" alt="Screenshot from 2026-05-05 16-09-55" src="https://github.com/user-attachments/assets/c0704f49-54fc-4c6f-aef0-91fd34d1a6f6" />
In the screenshot the upper right Assistant icon (circled in red) opens the default Assistant. It has no connection to the content of the Euro-Office canvas.
The new entry "Nextcloud Assistant" under "Insert" main menu  (circled in red) of Euro-Office opens the Assistant context aware. If text was marked, the text is copied into the input field of the Assistant. 

Things to discuss
* Usability issue, two Assistant icons doing almost same thing
* Where to position the "Nextcloud Assistant" menu entry in Euro-Office GUI
* How deep should the integration be? At the moment, markup is stripped. If a user marks for example a headline or a bold text, opens the Assistant, clicks "translate", the translated text is shown as normal unformatted text. No markup preserved. 

To make that feature work, one needs the web-apps counter part:
https://github.com/Euro-Office/web-apps/pull/58