### PR TITLE
fix: :bug: preserve percent-encoded URLs for createUrl and templates

### DIFF
--- a/lib/Controller/EditorApiController.php
+++ b/lib/Controller/EditorApiController.php
@@ -409,7 +409,7 @@ class EditorApiController extends OCSController {
                 $createParam["name"] = $createName;
 
                 $createUrl = $this->urlGenerator->linkToRouteAbsolute($this->appName . ".editor.create_new", $createParam);
-                $params["editorConfig"]["createUrl"] = urldecode((string) $createUrl);
+                $params["editorConfig"]["createUrl"] = $createUrl;
             }
 
             $templatesList = TemplateManager::getGlobalTemplates($file->getMimeType());
@@ -422,7 +422,7 @@ class EditorApiController extends OCSController {
                     $templates[] = [
                         "image" => "",
                         "title" => $templateItem->getName(),
-                        "url" => urldecode((string) $this->urlGenerator->linkToRouteAbsolute($this->appName . ".editor.create_new", $createParam))
+                        "url" => $this->urlGenerator->linkToRouteAbsolute($this->appName . ".editor.create_new", $createParam)
                     ];
                 }
 


### PR DESCRIPTION
urldecode() on linkToRouteAbsolute() output breaks special characters (e.g. & in folder names) by stripping their percent-encoding before the URL is consumed by the editor.

To Test: create a folder with `&` and create/edit a file in there in EO.