### PR TITLE
fix(templates): register TemplateFileCreator via RegisterTemplateCrea…

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -32,9 +32,7 @@ use OCP\AppFramework\Bootstrap\IRegistrationContext;
 use OCP\AppFramework\Http\Events\BeforeTemplateRenderedEvent as HttpBeforeTemplateRenderedEvent;
 use OCP\DirectEditing\RegisterDirectEditorEvent;
 use OCP\Files\Template\FileCreatedFromTemplateEvent;
-use OCP\Files\Template\ITemplateManager;
-use OCP\Files\Template\TemplateFileCreator;
-use OCP\IL10N;
+use OCP\Files\Template\RegisterTemplateCreatorEvent;
 use OCP\Security\CSP\AddContentSecurityPolicyEvent;
 use OCA\Files\Event\LoadAdditionalScriptsEvent;
 use OCA\Files_Sharing\Event\BeforeTemplateRenderedEvent;
@@ -46,6 +44,7 @@ use OCA\Eurooffice\Listeners\CreateFromTemplateListener;
 use OCA\Eurooffice\Listeners\FilesListener;
 use OCA\Eurooffice\Listeners\FileSharingListener;
 use OCA\Eurooffice\Listeners\DirectEditorListener;
+use OCA\Eurooffice\Listeners\RegisterTemplateCreatorListener;
 use OCA\Eurooffice\Listeners\ViewerListener;
 use OCA\Eurooffice\Listeners\WidgetListener;
 use OCA\Eurooffice\Events\DocumentUnsavedEvent;
@@ -95,6 +94,7 @@ class Application extends App implements IBootstrap {
         $context->registerEventListener(ShareDeletedEvent::class, ShareListener::class);
         $context->registerEventListener(UserDeletedEvent::class, UserListener::class);
         $context->registerEventListener(VersionRestoredEvent::class, FileVersionsListener::class);
+        $context->registerEventListener(RegisterTemplateCreatorEvent::class, RegisterTemplateCreatorListener::class);
 
         if (interface_exists(\OCP\Files\Template\ICustomTemplateProvider::class)) {
             $context->registerTemplateProvider(TemplateProvider::class);
@@ -108,36 +108,5 @@ class Application extends App implements IBootstrap {
     }
 
     public function boot(IBootContext $context): void {
-        if (class_exists(TemplateFileCreator::class)) {
-            $context->injectFn(function (ITemplateManager $templateManager, IL10N $trans, $appName): void {
-                if (!empty($this->appConfig->getDocumentServerUrl())
-                    && $this->appConfig->settingsAreSuccessful()
-                    && $this->appConfig->isUserAllowedToUse()) {
-                    $templateManager->registerTemplateFileCreator(function () use ($appName, $trans): TemplateFileCreator {
-                        $wordTemplate = new TemplateFileCreator($appName, $trans->t("New document"), ".docx");
-                        $wordTemplate->addMimetype("application/vnd.openxmlformats-officedocument.wordprocessingml.document");
-                        $wordTemplate->setIconSvgInline(file_get_contents(__DIR__ . '/../../img/new-docx.svg'));
-                        $wordTemplate->setRatio(21/29.7);
-                        return $wordTemplate;
-                    });
-
-                    $templateManager->registerTemplateFileCreator(function () use ($appName, $trans): TemplateFileCreator {
-                        $cellTemplate = new TemplateFileCreator($appName, $trans->t("New spreadsheet"), ".xlsx");
-                        $cellTemplate->addMimetype("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet");
-                        $cellTemplate->setIconSvgInline(file_get_contents(__DIR__ . '/../../img/new-xlsx.svg'));
-                        $cellTemplate->setRatio(21/29.7);
-                        return $cellTemplate;
-                    });
-
-                    $templateManager->registerTemplateFileCreator(function () use ($appName, $trans): TemplateFileCreator {
-                        $slideTemplate = new TemplateFileCreator($appName, $trans->t("New presentation"), ".pptx");
-                        $slideTemplate->addMimetype("application/vnd.openxmlformats-officedocument.presentationml.presentation");
-                        $slideTemplate->setIconSvgInline(file_get_contents(__DIR__ . '/../../img/new-pptx.svg'));
-                        $slideTemplate->setRatio(16/9);
-                        return $slideTemplate;
-                    });
-                }
-            });
-        }
     }
 }

--- a/lib/Listeners/RegisterTemplateCreatorListener.php
+++ b/lib/Listeners/RegisterTemplateCreatorListener.php
@@ -1,0 +1,83 @@
+<?php
+/**
+ *
+ * (c) Copyright Ascensio System SIA 2026
+ *
+ * This program is a free software product.
+ * You can redistribute it and/or modify it under the terms of the GNU Affero General Public License
+ * (AGPL) version 3 as published by the Free Software Foundation.
+ * In accordance with Section 7(a) of the GNU AGPL its Section 15 shall be amended to the effect
+ * that Ascensio System SIA expressly excludes the warranty of non-infringement of any third-party rights.
+ *
+ * This program is distributed WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * For details, see the GNU AGPL at: http://www.gnu.org/licenses/agpl-3.0.html
+ *
+ * The interactive user interfaces in modified source and object code versions of the Program
+ * must display Appropriate Legal Notices, as required under Section 5 of the GNU AGPL version 3.
+ *
+ *
+ * All the Product's GUI elements, including illustrations and icon sets, as well as technical
+ * writing content are licensed under the terms of the Creative Commons Attribution-ShareAlike 4.0 International.
+ * See the License terms at http://creativecommons.org/licenses/by-sa/4.0/legalcode
+ *
+ */
+
+namespace OCA\Eurooffice\Listeners;
+
+use OCA\Eurooffice\AppConfig;
+use OCA\Eurooffice\AppInfo\Application;
+use OCP\EventDispatcher\Event;
+use OCP\EventDispatcher\IEventListener;
+use OCP\Files\Template\RegisterTemplateCreatorEvent;
+use OCP\Files\Template\TemplateFileCreator;
+use OCP\IL10N;
+
+/** @template-implements IEventListener<Event|RegisterTemplateCreatorEvent> */
+class RegisterTemplateCreatorListener implements IEventListener {
+
+    public function __construct(
+        private readonly AppConfig $appConfig,
+        private readonly IL10N $l10n,
+    ) {}
+
+    public function handle(Event $event): void {
+        if (!$event instanceof RegisterTemplateCreatorEvent) {
+            return;
+        }
+
+        if (empty($this->appConfig->getDocumentServerUrl())
+            || !$this->appConfig->settingsAreSuccessful()
+            || !$this->appConfig->isUserAllowedToUse()) {
+            return;
+        }
+
+        $templateManager = $event->getTemplateManager();
+        $appName = Application::APP_ID;
+        $imgDir = __DIR__ . '/../../img';
+
+        $templateManager->registerTemplateFileCreator(function () use ($appName, $imgDir): TemplateFileCreator {
+            $wordTemplate = new TemplateFileCreator($appName, $this->l10n->t('New document'), '.docx');
+            $wordTemplate->addMimetype('application/vnd.openxmlformats-officedocument.wordprocessingml.document');
+            $wordTemplate->setIconSvgInline(file_get_contents($imgDir . '/new-docx.svg'));
+            $wordTemplate->setRatio(21 / 29.7);
+            return $wordTemplate;
+        });
+
+        $templateManager->registerTemplateFileCreator(function () use ($appName, $imgDir): TemplateFileCreator {
+            $cellTemplate = new TemplateFileCreator($appName, $this->l10n->t('New spreadsheet'), '.xlsx');
+            $cellTemplate->addMimetype('application/vnd.openxmlformats-officedocument.spreadsheetml.sheet');
+            $cellTemplate->setIconSvgInline(file_get_contents($imgDir . '/new-xlsx.svg'));
+            $cellTemplate->setRatio(21 / 29.7);
+            return $cellTemplate;
+        });
+
+        $templateManager->registerTemplateFileCreator(function () use ($appName, $imgDir): TemplateFileCreator {
+            $slideTemplate = new TemplateFileCreator($appName, $this->l10n->t('New presentation'), '.pptx');
+            $slideTemplate->addMimetype('application/vnd.openxmlformats-officedocument.presentationml.presentation');
+            $slideTemplate->setIconSvgInline(file_get_contents($imgDir . '/new-pptx.svg'));
+            $slideTemplate->setRatio(16 / 9);
+            return $slideTemplate;
+        });
+    }
+}


### PR DESCRIPTION
…torEvent listener

Application::boot() runs before the user session exists, so isUserAllowedToUse() always returned false during boot and creators were never registered when group restrictions were configured.

This replaces boot-time registration with a RegisterTemplateCreatorListener that handles RegisterTemplateCreatorEvent, dispatched by TemplateManager::getTypes() during a user request where the session exists. isUserAllowedToUse() now works correctly and the group restriction gate is preserved.

Mirrors the pattern used by richdocuments' RegisterTemplateFileCreatorListener.