### PR TITLE
fix(viewer): use Object.values() to iterate formats object

### DIFF
--- a/src/viewer.js
+++ b/src/viewer.js
@@ -79,7 +79,7 @@
 	if (OCA.Viewer) {
 		OCA.Eurooffice.frameSelector = '#euroofficeViewerFrame'
 
-		const mimes = OCA.Eurooffice.setting.formats
+		const mimes = Object.values(OCA.Eurooffice.setting.formats)
 			.filter(format => format.def)
 			.map(format => format.mime)
 			.flat()


### PR DESCRIPTION
## Summary

Fixes a `TypeError` that prevented EuroOffice from registering its MIME types with `OCA.Viewer`, causing the recommendation widget to navigate to files rather than open them in the editor.

**Root cause:** `AppConfig::buildEuroofficeFormats()` returns a PHP associative array keyed by format name (`{"docx": {...}, "xlsx": {...}}`). PHP associative arrays serialise to JSON **objects**, not arrays. Calling `.filter()` on an object throws a `TypeError` at script load time — before `registerHandler()` is ever reached — so office MIME types are never added to `OCA.Viewer.mimetypes`.

**Change:** Wrap `setting.formats` with `Object.values()` so the native array methods work correctly regardless of how the PHP side serialises the data.

The ONLYOFFICE upstream (`ONLYOFFICE/onlyoffice-nextcloud`) used jQuery's `$.map()` which handles both arrays and objects. This bug was introduced when the jQuery dependency was removed and the line was rewritten using native array methods.

## Test plan

- [ ] Open a `.docx` / `.xlsx` / `.odt` in the browser; `OCA.Viewer.mimetypes` should include office MIME types
- [ ] Clicking a document in the **Recommended files** widget opens it in EuroOffice (not just navigates to it)
- [ ] Opening from the Files list no longer logs "No files provided" in the console

Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)