### PR TITLE
fix(css): fix file action icons invisible in dark themes

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -32,6 +32,11 @@
     -webkit-mask-size: 16px 16px;
 }
 
+/* Fix: file action SVG icons have hardcoded fill="#000" — use Nextcloud's adaptive text token */
+.files-list__row-action-icon path {
+    fill: var(--color-main-text);
+}
+
 /* eurooffice-inline */
 #body-user.eurooffice-inline #app-navigation,
 #body-user.eurooffice-inline .app-navigation,


### PR DESCRIPTION
Fixes #72

## Problem

`.files-list__row-action-icon` SVG paths have `fill="#000"` hardcoded as a presentation attribute, making them near-invisible on dark and contrast-dark backgrounds.

## Fix

One CSS rule in `main.css` — CSS declarations beat SVG presentation attributes so no `!important` is needed. Uses Nextcloud's own `--color-main-text` adaptive token, which is already used for the existing `.icon-eurooffice-*` mask icons in this file:

```css
.files-list__row-action-icon path {
    fill: var(--color-main-text);
}
```

## Related

- Euro-Office/web-apps#136 — companion fix for icons inside the editor itself
- Euro-Office/web-apps#120 — original bug report
- https://github.com/nextcloud/office/issues/43 — upstream report

## Testing

- [ ] Enable Dark theme — file action icons visible in file list
- [ ] Enable Contrast Dark theme — file action icons visible
- [ ] Light/default theme — icons unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)