### PR TITLE
chore: switch document-templates submodule to Euro-Office fork

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "assets/document-templates"]
 	path = assets/document-templates
-	url = https://github.com/ONLYOFFICE/document-templates
-	branch = main/new
+	url = https://github.com/Euro-Office/document-templates
+	branch = main
 [submodule "assets/document-formats"]
 	path = assets/document-formats
 	url = https://github.com/ONLYOFFICE/document-formats


### PR DESCRIPTION
Replace upstream ONLYOFFICE/document-templates with the Euro-Office fork. Two changes are bundled together:

- .gitmodules: update url to Euro-Office/document-templates and branch from main/new to main. The branch main/new cannot coexist with a main branch in git refs; the Euro-Office fork uses main with locale dirs at the repo root instead.
- Submodule pointer: advance to the commit that moves locale dirs from new/<locale>/ to <locale>/ at root, matching the path that TemplateManager.php constructs when serving blank document templates.