### PR TITLE
🐛 fix(viewer): iterate formats object with Object.values() (#77)

### DIFF
--- a/src/viewer.js
+++ b/src/viewer.js
@@ -79,7 +79,7 @@
 	if (OCA.Viewer) {
 		OCA.Eurooffice.frameSelector = '#euroofficeViewerFrame'
 
-		const mimes = OCA.Eurooffice.setting.formats
+		const mimes = Object.values(OCA.Eurooffice.setting.formats)
 			.filter(format => format.def)
 			.map(format => format.mime)
 			.flat()


### PR DESCRIPTION
`OCA.Eurooffice.setting.formats` is an object keyed by extension, not an array, so `.filter` throws at module load — `TypeError: …formats.filter is not a function` — and the Viewer handler never registers.

Forward-port of #37, which fixed this on `stable11` but never reached `main`. `main` (and v11.0.0) still ship the broken `.filter`, introduced by the jQuery→native refactor (51e2d6a9): `$.map` walks objects, `Array.filter` doesn't.

Audited the other `$.each`/`$.map`→native conversions from that refactor — the rest operate on real arrays, so this is the only regression.

Fixes #77
Fixes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)