### PR TITLE
release: bump to 11.0.1, fix license identifier to AGPL-3.0-only

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -13,10 +13,10 @@ Furthermore, you can seamlessly connect any AI assistant, including local ones, 
 
 Whether you’re working with internal teams or external collaborators, the Nextcloud Office app for Nextcloud enhances productivity, simplifies workflows, and ensures your files remain secure.
 ]]></description>
-    <licence>agpl</licence>
+    <licence>AGPL-3.0-only</licence>
 	<author>Nextcloud Office contributors</author>
     <author mail="dev@onlyoffice.com" homepage="https://www.onlyoffice.com/">Ascensio System SIA</author>
-    <version>11.0.0</version>
+    <version>11.0.1</version>
     <namespace>Eurooffice</namespace>
     <types>
         <prevent_group_restriction/>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "eurooffice",
-    "version": "11.0.0",
+    "version": "11.0.1",
     "description": "Euro-Office app for Nextcloud — view, edit and collaborate on documents, spreadsheets and presentations using Euro-Office Docs.",
     "homepage": "https://github.com/Euro-Office/eurooffice-nextcloud",
     "author": "Euro-Office contributors",


### PR DESCRIPTION
Bumps the version to 11.0.1 and fixes the license identifier in `appinfo/info.xml` from `agpl` to `AGPL-3.0-only`.

The source code headers use "AGPL version 3" without an "or later" clause, so `AGPL-3.0-only` is the correct SPDX identifier to match `package.json` (which already uses `AGPL-3.0`).