### PR TITLE
ci: restrict release/create-tag workflows to Euro-Office org

### DIFF
--- a/.github/workflows/create-tag.yml
+++ b/.github/workflows/create-tag.yml
@@ -12,6 +12,8 @@ on:
 jobs:
   create-tag:
     runs-on: ubuntu-latest
+    # Only run in the source org — never inside nextcloud-releases.
+    if: ${{ github.repository_owner == 'Euro-Office' }}
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,9 @@ permissions:
 jobs:
   release:
     runs-on: ubuntu-latest
+    # Only run in the source org — never inside nextcloud-releases, where a
+    # token-created release would not trigger appstore-build-publish.yml.
+    if: ${{ github.repository_owner == 'Euro-Office' }}
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v6


### PR DESCRIPTION
## Why

`release.yml` and `create-tag.yml` live in `.github/workflows/`, so they travel with the code. The App Store release process pushes the release **tag to `nextcloud-releases/eurooffice`** (`git push release vX.Y.Z`). When that happens, these workflows land there too and run on the tag push — `release.yml` auto-creates a GitHub Release using `GITHUB_TOKEN`, which **cannot trigger** `appstore-build-publish.yml` (GitHub blocks token-triggered workflows). 

## What

Guard both jobs with:

```yaml
if: ${{ github.repository_owner == 'Euro-Office' }}
```

- In `Euro-Office/eurooffice-nextcloud` → runs as before (still auto-creates the dev-side release).
- In `nextcloud-releases/eurooffice` → **skips**, so no bot release; a human publishes the release there and that triggers the store publish.

No behavior change for normal development in this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)