### PR TITLE
🐛 fix: guard JSON.parse of share-attributes against missing value

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -508,6 +508,13 @@ import { loadState } from '@nextcloud/initial-state'
 			return config
 		}
 
+		const isDownloadDisabledByShareAttributes = function(file) {
+			const shareAttributes = JSON.parse(file.attributes['share-attributes'] || '[]')
+			const downloadAttribute = shareAttributes.find((attribute) => attribute.scope === 'permissions' && attribute.key === 'download')
+
+			return downloadAttribute !== undefined && downloadAttribute.enabled === false
+		}
+
 		if (OCA.Files && OCA.Files.fileActions) {
 			Object.entries(formats).forEach(([ext, config]) => {
 				if (!config.mime) {
@@ -618,9 +625,7 @@ import { loadState } from '@nextcloud/initial-state'
 					if (files[0].attributes['mount-type'] === 'shared') {
 						if (required !== (files[0].attributes['share-permissions'] & required)) { return false }
 
-						const attributes = JSON.parse(files[0].attributes['share-attributes'])
-						const downloadAttribute = attributes.find((attribute) => attribute.scope === 'permissions' && attribute.key === 'download')
-						if (downloadAttribute !== undefined && downloadAttribute.enabled === false) { return false }
+						if (isDownloadDisabledByShareAttributes(files[0])) { return false }
 					}
 
 					return true
@@ -644,9 +649,7 @@ import { loadState } from '@nextcloud/initial-state'
 					if (files[0].attributes['mount-type'] === 'shared') {
 						if (required !== (files[0].attributes['share-permissions'] & required)) { return false }
 
-						const attributes = JSON.parse(files[0].attributes['share-attributes'])
-						const downloadAttribute = attributes.find((attribute) => attribute.scope === 'permissions' && attribute.key === 'download')
-						if (downloadAttribute !== undefined && downloadAttribute.enabled === false) { return false }
+						if (isDownloadDisabledByShareAttributes(files[0])) { return false }
 					}
 
 					return true
@@ -671,9 +674,7 @@ import { loadState } from '@nextcloud/initial-state'
 						if (Permission.READ !== (files[0].permissions & Permission.READ)) { return false }
 
 						if (files[0].attributes['mount-type'] === 'shared') {
-							const attributes = JSON.parse(files[0].attributes['share-attributes'])
-							const downloadAttribute = attributes.find((attribute) => attribute.scope === 'permissions' && attribute.key === 'download')
-							if (downloadAttribute !== undefined && downloadAttribute.enabled === false) { return false }
+							if (isDownloadDisabledByShareAttributes(files[0])) { return false }
 						}
 
 						return true

--- a/src/main.js
+++ b/src/main.js
@@ -509,7 +509,17 @@ import { loadState } from '@nextcloud/initial-state'
 		}
 
 		const isDownloadDisabledByShareAttributes = function(file) {
-			const shareAttributes = JSON.parse(file.attributes['share-attributes'] || '[]')
+			let shareAttributes
+			try {
+				shareAttributes = JSON.parse(file.attributes['share-attributes'] || '[]')
+			} catch {
+				return false
+			}
+
+			if (!Array.isArray(shareAttributes)) {
+				return false
+			}
+
 			const downloadAttribute = shareAttributes.find((attribute) => attribute.scope === 'permissions' && attribute.key === 'download')
 
 			return downloadAttribute !== undefined && downloadAttribute.enabled === false

--- a/src/main.js
+++ b/src/main.js
@@ -522,7 +522,7 @@ import { loadState } from '@nextcloud/initial-state'
 
 			const downloadAttribute = shareAttributes.find((attribute) => attribute.scope === 'permissions' && attribute.key === 'download')
 
-			return downloadAttribute !== undefined && downloadAttribute.enabled === false
+			return downloadAttribute !== undefined && downloadAttribute.value !== true
 		}
 
 		if (OCA.Files && OCA.Files.fileActions) {


### PR DESCRIPTION
Fixes #95

`share-attributes` isn't guaranteed to be set, so `JSON.parse` on it throws and the eurooffice file actions vanish from the menu instead of evaluating permissions. Falls back to `'[]'` (matches `nextcloud/server`'s `isDownloadable()`) and dedupes the three copies into one helper.