### PR TITLE
Rename App Summry to "Nextcloud Office, powered by Euro-Office"

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0"?>
 <info>
     <id>eurooffice</id>
-    <name>Nextcloud Office (Euro-Office)</name>
-    <summary>Nextcloud Office app</summary>
+    <name>Nextcloud Office</name>
+    <summary>Nextcloud Office, powered by Euro-Office</summary>
     <description><![CDATA[The Nextcloud Office app for Nextcloud brings powerful document editing and collaboration tools directly to your Nextcloud environment. With this integration, you can seamlessly create, edit, and co-author text documents, spreadsheets, presentations, and PDFs, as well as build and fill out PDF forms.
 
 Collaborate with your team in real time, make use of Track Changes, version history, comments, integrated chat, and more. Work together on files with federated cloud sharing. Flexible access permissions allow you to control who can view, edit, or comment, ensuring secure role-based collaboration tailored to your needs. Documents can also be protected with watermarks, password settings, and encryption for added security.

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <info>
     <id>eurooffice</id>
-    <name>Nextcloud Office</name>
+    <name>Nextcloud Office (Euro-Office)</name>
     <summary>Nextcloud Office app</summary>
     <description><![CDATA[The Nextcloud Office app for Nextcloud brings powerful document editing and collaboration tools directly to your Nextcloud environment. With this integration, you can seamlessly create, edit, and co-author text documents, spreadsheets, presentations, and PDFs, as well as build and fill out PDF forms.
 


### PR DESCRIPTION
## Problem

There are currently two `Nextcloud Office` apps in the App Store:

* `Nextcloud Office` => https://github.com/Euro-Office/eurooffice-nextcloud
* `Nextcloud Office (Collabora)` => https://github.com/nextcloud/richdocuments

<details>

<summary>Screenshot</summary>

<img width="891" height="216" alt="Screenshot 2026-07-23 at 18 32 16" src="https://github.com/user-attachments/assets/9390b701-bc70-4cb8-b265-4ef74020496c" />

</details>

The first one doesn’t immediately make it clear what it is.

That’s especially true if someone is trying to set up Euro-Office but has never heard of Collabora. For me it’s obvious that the first one must be Euro-Office, but for someone never ever heard of Collabora, it could be misleading/confusing.

## Proposal

Mention Euro-Office in the app summary.