### PR TITLE
Add native close control and honor same-tab mobile setting

### DIFF
--- a/lib/Controller/EditorApiController.php
+++ b/lib/Controller/EditorApiController.php
@@ -436,6 +436,10 @@ class EditorApiController extends OCSController {
         }
 
         $canGoBack = $folderLink !== null;
+        if ($canGoBack) {
+            $params["_folder_link"] = $folderLink;
+        }
+
         if ($inviewer) {
             if ($canGoBack) {
                 $params["editorConfig"]["customization"]["goback"] = [

--- a/lib/Controller/EditorApiController.php
+++ b/lib/Controller/EditorApiController.php
@@ -456,6 +456,12 @@ class EditorApiController extends OCSController {
             $params["editorConfig"]["customization"]["close"]["visible"] = true;
         }
 
+        // The editor renders this as its native close control in the header.
+        // Keep it available for standalone windows and viewer integrations too.
+        if (!$desktop) {
+            $params["editorConfig"]["customization"]["close"]["visible"] = true;
+        }
+
         if (!$canDownload || $this->appConfig->getDisableDownload()) {
             $params["document"]["permissions"]["download"] = false;
             $params["document"]["permissions"]["print"] = false;

--- a/src/editor.js
+++ b/src/editor.js
@@ -187,9 +187,7 @@ import axios from '@nextcloud/axios'
 							}
 						}
 
-						if (OCA.Eurooffice.directEditor || OCA.Eurooffice.inframe) {
-							config.events.onRequestClose = OCA.Eurooffice.onRequestClose
-						}
+						config.events.onRequestClose = OCA.Eurooffice.onRequestClose
 
 						if (OCA.Eurooffice.inframe
 							&& config._files_sharing && !OCA.Eurooffice.shareToken
@@ -467,12 +465,25 @@ import axios from '@nextcloud/axios'
 			return
 		}
 
-		OCA.Eurooffice.docEditor.destroyEditor()
+		if (OCA.Eurooffice.docEditor) {
+			OCA.Eurooffice.docEditor.destroyEditor()
+		}
 
-		window.parent.postMessage({
-			method: 'editorRequestClose',
-		},
-		'*')
+		if (OCA.Eurooffice.inframe) {
+			window.parent.postMessage({
+				method: 'editorRequestClose',
+			},
+			'*')
+			return
+		}
+
+		if (window.opener && !window.opener.closed) {
+			window.opener.focus()
+		}
+		window.close()
+		if (!window.closed) {
+			window.location.assign(OC.generateUrl('/apps/files'))
+		}
 	}
 
 	OCA.Eurooffice.onRequestSharingSettings = function() {

--- a/src/editor.js
+++ b/src/editor.js
@@ -74,6 +74,7 @@ import axios from '@nextcloud/axios'
 				const config = response.data
 				if (config) {
 					OCA.Eurooffice.device = config.type
+					OCA.Eurooffice.folderLink = config._folder_link || OC.generateUrl('/apps/files')
 					if (OCA.Eurooffice.device === 'mobile') {
 						OCA.Eurooffice.resizeEvents()
 					}
@@ -477,13 +478,16 @@ import axios from '@nextcloud/axios'
 			return
 		}
 
+		const returnUrl = OCA.Eurooffice.folderLink || OC.generateUrl('/apps/files')
 		if (window.opener && !window.opener.closed) {
 			window.opener.focus()
+			window.close()
+			if (window.closed) {
+				return
+			}
 		}
-		window.close()
-		if (!window.closed) {
-			window.location.assign(OC.generateUrl('/apps/files'))
-		}
+
+		window.location.replace(returnUrl)
 	}
 
 	OCA.Eurooffice.onRequestSharingSettings = function() {

--- a/src/main.js
+++ b/src/main.js
@@ -65,8 +65,6 @@ import { loadState } from '@nextcloud/initial-state'
 	}, OCA.Eurooffice)
 
 	OCA.Eurooffice.setting = OCP.InitialState.loadState(OCA.Eurooffice.AppName, 'settings')
-	OCA.Eurooffice.mobile = /Android|webOS|iPhone|iPad|iPod|BlackBerry|BB|PlayBook|IEMobile|Windows Phone|Kindle|Silk|Opera Mini|Macintosh/i.test(navigator.userAgent)
-							&& navigator.maxTouchPoints && navigator.maxTouchPoints > 1
 
 	OCA.Eurooffice.CreateFile = function(name, fileList, templateId, targetId, open = true) {
 		const dir = fileList.getCurrentDirectory()
@@ -107,7 +105,7 @@ import { loadState } from '@nextcloud/initial-state'
 
 	OCA.Eurooffice.CreateFileProcess = function(name, dir, templateId, targetId, open, callback) {
 		let winEditor = null
-		if (((!OCA.Eurooffice.setting.sameTab && !OCA.Eurooffice.setting.enableSharing) || OCA.Eurooffice.mobile || OCA.Eurooffice.Desktop) && open) {
+		if (((!OCA.Eurooffice.setting.sameTab && !OCA.Eurooffice.setting.enableSharing) || OCA.Eurooffice.Desktop) && open) {
 			const loaderUrl = OCA.Eurooffice.Desktop ? '' : OC.filePath(OCA.Eurooffice.AppName, 'templates', 'loader.html')
 			winEditor = window.open(loaderUrl)
 		}
@@ -185,7 +183,7 @@ import { loadState } from '@nextcloud/initial-state'
 			OCA.Eurooffice.SetDefaultUrl()
 			winEditor.location.href = url
 		} else if ((!OCA.Eurooffice.setting.sameTab && !OCA.Eurooffice.setting.enableSharing)
-			|| OCA.Eurooffice.mobile || OCA.Eurooffice.Desktop || (isPublicShare() && !OCA.Eurooffice.isViewIsFile()
+			|| OCA.Eurooffice.Desktop || (isPublicShare() && !OCA.Eurooffice.isViewIsFile()
 			&& !OCA.Eurooffice.setting.sameTab && OCA.Eurooffice.setting.enableSharing)
 			|| (!OCA.Eurooffice.setting.sameTab && !isDefault)) {
 			OCA.Eurooffice.SetDefaultUrl()


### PR DESCRIPTION
## What changed

- expose the document server's native close control in all non-desktop-client editor configurations
- register `onRequestClose` for standalone editor windows as well as embedded/direct editors
- provide the opened file's parent-folder URL to the editor close handler
- return same-tab editors to that folder on desktop and mobile
- honor the same-tab setting on tablets and mobile devices instead of forcing a new browser tab

## Why

The close event was only registered for direct-editor and iframe sessions, while the close customization was only enabled in a limited set of embedded modes. Tablet browsers using the desktop version could therefore open the standalone editor without the native close button in the program header. The standalone fallback also returned to the Files root instead of the folder containing the document.

A legacy mobile-device override additionally called `window.open()` even when the administrator enabled "Open file in the same tab". This made the setting ineffective on tablets, including browsers using desktop mode.

## User impact

Users get the native X control at the far right of the EuroOffice header. Closing a same-tab editor returns to the folder containing the opened file. Tablets and mobile devices now respect the administrator's same-tab choice. Separate editor tabs still close and focus their opener, with the correct folder URL as the browser fallback.

## Validation

- `npm run build`
- `php -l lib/Controller/EditorApiController.php`
- verified with Nextcloud 34.0.2 and EuroOffice 11.0.1
- verified same-tab opening and folder return on a tablet
