### PR TITLE
fix(deps): bump stylelint stack together to resolve peer conflict

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -23,10 +23,10 @@
             "devDependencies": {
                 "@nextcloud/browserslist-config": "^3.1.2",
                 "@nextcloud/eslint-config": "^8.4.1",
-                "@nextcloud/stylelint-config": "^3.0.1",
+                "@nextcloud/stylelint-config": "^3.2.2",
                 "@nextcloud/vite-config": "^2.5.2",
-                "stylelint": "^16.26.1",
-                "stylelint-config-standard": "^36.0.1",
+                "stylelint": "^17.9.1",
+                "stylelint-config-standard": "^40.0.0",
                 "vite": "^7.3.1"
             }
         },
@@ -378,13 +378,13 @@
             }
         },
         "node_modules/@cacheable/memory": {
-            "version": "2.0.8",
-            "resolved": "https://registry.npmjs.org/@cacheable/memory/-/memory-2.0.8.tgz",
-            "integrity": "sha512-FvEb29x5wVwu/Kf93IWwsOOEuhHh6dYCJF3vcKLzXc0KXIW181AOzv6ceT4ZpBHDvAfG60eqb+ekmrnLHIy+jw==",
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@cacheable/memory/-/memory-2.2.0.tgz",
+            "integrity": "sha512-CTLKqLItRCEixEAewD3/j9DB3/o96gpTPD4eJ1v+DGOlxZRZncRQkGYqqnAGCscYd6RNeXfGeiuCphsPtqyIfQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@cacheable/utils": "^2.4.0",
+                "@cacheable/utils": "^2.5.0",
                 "@keyv/bigmap": "^1.3.1",
                 "hookified": "^1.15.1",
                 "keyv": "^5.6.0"
@@ -418,13 +418,13 @@
             }
         },
         "node_modules/@cacheable/utils": {
-            "version": "2.4.0",
-            "resolved": "https://registry.npmjs.org/@cacheable/utils/-/utils-2.4.0.tgz",
-            "integrity": "sha512-PeMMsqjVq+bF0WBsxFBxr/WozBJiZKY0rUojuaCoIaKnEl3Ju1wfEwS+SV1DU/cSe8fqHIPiYJFif8T3MVt4cQ==",
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/@cacheable/utils/-/utils-2.5.0.tgz",
+            "integrity": "sha512-buipgOVDkkPXNR5+xBpDw7Zk2n1EvU7qBJCNUcL7rhQ//kfpOXPAvQ511Os0vpLYJ1pZnvudNytkQt2hst3wqA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "hashery": "^1.5.0",
+                "hashery": "^1.5.1",
                 "keyv": "^5.6.0"
             }
         },
@@ -454,33 +454,10 @@
                 "vue": "^3.2.0"
             }
         },
-        "node_modules/@csstools/css-parser-algorithms": {
-            "version": "3.0.5",
-            "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
-            "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/csstools"
-                },
-                {
-                    "type": "opencollective",
-                    "url": "https://opencollective.com/csstools"
-                }
-            ],
-            "license": "MIT",
-            "engines": {
-                "node": ">=18"
-            },
-            "peerDependencies": {
-                "@csstools/css-tokenizer": "^3.0.4"
-            }
-        },
         "node_modules/@csstools/css-syntax-patches-for-csstree": {
-            "version": "1.0.28",
-            "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.0.28.tgz",
-            "integrity": "sha512-1NRf1CUBjnr3K7hu8BLxjQrKCxEe8FP/xmPTenAxCRZWVLbmGotkFvG9mfNpjA6k7Bw1bw4BilZq9cu19RA5pg==",
+            "version": "1.1.7",
+            "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.7.tgz",
+            "integrity": "sha512-fQ+05118eQS1cofO3aJpB5efgpBZMvIzwr/sbC8kDLVA5XLG8q1kJV5yzrUAI1f7lvhPnm8fgIjzFB8/O/5Dig==",
             "dev": true,
             "funding": [
                 {
@@ -492,50 +469,14 @@
                     "url": "https://opencollective.com/csstools"
                 }
             ],
-            "license": "MIT-0"
-        },
-        "node_modules/@csstools/css-tokenizer": {
-            "version": "3.0.4",
-            "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
-            "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/csstools"
-                },
-                {
-                    "type": "opencollective",
-                    "url": "https://opencollective.com/csstools"
-                }
-            ],
-            "license": "MIT",
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@csstools/media-query-list-parser": {
-            "version": "4.0.3",
-            "resolved": "https://registry.npmjs.org/@csstools/media-query-list-parser/-/media-query-list-parser-4.0.3.tgz",
-            "integrity": "sha512-HAYH7d3TLRHDOUQK4mZKf9k9Ph/m8Akstg66ywKR4SFAigjs3yBiUeZtFxywiTm5moZMAp/5W/ZuFnNXXYLuuQ==",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/csstools"
-                },
-                {
-                    "type": "opencollective",
-                    "url": "https://opencollective.com/csstools"
-                }
-            ],
-            "license": "MIT",
-            "engines": {
-                "node": ">=18"
-            },
+            "license": "MIT-0",
             "peerDependencies": {
-                "@csstools/css-parser-algorithms": "^3.0.5",
-                "@csstools/css-tokenizer": "^3.0.4"
+                "css-tree": "^3.2.1"
+            },
+            "peerDependenciesMeta": {
+                "css-tree": {
+                    "optional": true
+                }
             }
         },
         "node_modules/@ctrl/tinycolor": {
@@ -545,17 +486,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">=10"
-            }
-        },
-        "node_modules/@dual-bundle/import-meta-resolve": {
-            "version": "4.2.1",
-            "resolved": "https://registry.npmjs.org/@dual-bundle/import-meta-resolve/-/import-meta-resolve-4.2.1.tgz",
-            "integrity": "sha512-id+7YRUgoUX6CgV0DtuhirQWodeeA7Lf4i2x71JS/vtA5pRb/hIGWlw+G6MeXvsM+MXrz0VAydTGElX1rAfgPg==",
-            "dev": true,
-            "license": "MIT",
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/JounQin"
             }
         },
         "node_modules/@es-joy/jsdoccomment": {
@@ -1736,18 +1666,21 @@
             }
         },
         "node_modules/@nextcloud/stylelint-config": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/@nextcloud/stylelint-config/-/stylelint-config-3.0.1.tgz",
-            "integrity": "sha512-xZ9hhyDCK8bMxPchfcyMhGZ8oTG+H+fmzE+vvCIVni0O+SzCVBEKDuvtKWZJDUs3ngmnmNYN1tH5xjbZBBeYyw==",
+            "version": "3.2.2",
+            "resolved": "https://registry.npmjs.org/@nextcloud/stylelint-config/-/stylelint-config-3.2.2.tgz",
+            "integrity": "sha512-5rr77fGK+zoa8yN+8zR43XbqyuN/yB2wSAy4vKE2F+hgAeOhpUAyChV+pfySDbP20t4s22DHgn7BDiZKsbNE3Q==",
             "dev": true,
+            "license": "AGPL-3.0-or-later",
+            "dependencies": {
+                "stylelint-use-logical": "^2.1.3"
+            },
             "engines": {
-                "node": "^20.0.0",
-                "npm": "^10.0.0"
+                "node": "^20.19 || ^22 || ^24"
             },
             "peerDependencies": {
-                "stylelint": "^16.2.0",
-                "stylelint-config-recommended-scss": "^14.0.0",
-                "stylelint-config-recommended-vue": "^1.5.0"
+                "stylelint": "^17.9.1",
+                "stylelint-config-recommended-scss": "^17.0.1",
+                "stylelint-config-recommended-vue": "^1.6.1"
             }
         },
         "node_modules/@nextcloud/typings": {
@@ -2525,6 +2458,19 @@
             "license": "MIT",
             "dependencies": {
                 "sprintf-js": "~1.0.2"
+            }
+        },
+        "node_modules/@sindresorhus/merge-streams": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-4.0.0.tgz",
+            "integrity": "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/@tokenizer/token": {
@@ -3388,6 +3334,7 @@
             "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
             "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": ">=8"
             }
@@ -3931,17 +3878,17 @@
             "license": "MIT"
         },
         "node_modules/cacheable": {
-            "version": "2.3.3",
-            "resolved": "https://registry.npmjs.org/cacheable/-/cacheable-2.3.3.tgz",
-            "integrity": "sha512-iffYMX4zxKp54evOH27fm92hs+DeC1DhXmNVN8Tr94M/iZIV42dqTHSR2Ik4TOSPyOAwKr7Yu3rN9ALoLkbWyQ==",
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/cacheable/-/cacheable-2.5.0.tgz",
+            "integrity": "sha512-60cyAOytib/OzBw1JNSoSV/boK1AtHryDIjvVBk7XbN4ugfkM3+Sry7fEjNgPMGgOjuaZPAp8ruZ0Cxafwyq9g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@cacheable/memory": "^2.0.8",
-                "@cacheable/utils": "^2.4.0",
+                "@cacheable/memory": "^2.2.0",
+                "@cacheable/utils": "^2.5.0",
                 "hookified": "^1.15.0",
                 "keyv": "^5.6.0",
-                "qified": "^0.6.0"
+                "qified": "^0.10.1"
             }
         },
         "node_modules/cacheable/node_modules/keyv": {
@@ -4276,10 +4223,11 @@
             "dev": true
         },
         "node_modules/cosmiconfig": {
-            "version": "9.0.0",
-            "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.0.tgz",
-            "integrity": "sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==",
+            "version": "9.0.2",
+            "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.2.tgz",
+            "integrity": "sha512-gtTZxTDau1wL7Y7zifc2dd8jHSK/k6BTx/2Xp/BpdlAdnlYWFVt7qhJqgwi7637yRwRQ3qL4ZidbB4I8tA5VOg==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "env-paths": "^2.2.1",
                 "import-fresh": "^3.3.0",
@@ -4413,14 +4361,14 @@
             }
         },
         "node_modules/css-tree": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.1.0.tgz",
-            "integrity": "sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w==",
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+            "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "mdn-data": "2.12.2",
-                "source-map-js": "^1.0.1"
+                "mdn-data": "2.27.1",
+                "source-map-js": "^1.2.1"
             },
             "engines": {
                 "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
@@ -4679,6 +4627,7 @@
             "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
             "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "path-type": "^4.0.0"
             },
@@ -6218,9 +6167,9 @@
             }
         },
         "node_modules/flatted": {
-            "version": "3.3.3",
-            "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-            "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+            "version": "3.4.3",
+            "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.3.tgz",
+            "integrity": "sha512-/zipXxyO6rGvuNGDiULY9MvEGSkb2gaG4GGH4ygMi0ZZzyMHdUZBmntJmx5x1G2VuPytCwGN4xsJP6cw+sK+vQ==",
             "dev": true,
             "license": "ISC"
         },
@@ -6399,6 +6348,19 @@
             "peer": true,
             "engines": {
                 "node": ">=6.9.0"
+            }
+        },
+        "node_modules/get-east-asian-width": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+            "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/get-intrinsic": {
@@ -6597,6 +6559,7 @@
             "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
             "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "array-union": "^2.1.0",
                 "dir-glob": "^3.0.1",
@@ -6737,13 +6700,13 @@
             }
         },
         "node_modules/hashery": {
-            "version": "1.5.0",
-            "resolved": "https://registry.npmjs.org/hashery/-/hashery-1.5.0.tgz",
-            "integrity": "sha512-nhQ6ExaOIqti2FDWoEMWARUqIKyjr2VcZzXShrI+A3zpeiuPWzx6iPftt44LhP74E5sW36B75N6VHbvRtpvO6Q==",
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/hashery/-/hashery-1.5.1.tgz",
+            "integrity": "sha512-iZyKG96/JwPz1N55vj2Ie2vXbhu440zfUfJvSwEqEbeLluk7NnapfGqa7LH0mOsnDxTF85Mx8/dyR6HfqcbmbQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "hookified": "^1.14.0"
+                "hookified": "^1.15.0"
             },
             "engines": {
                 "node": ">=20"
@@ -6878,12 +6841,13 @@
             "license": "MIT"
         },
         "node_modules/html-tags": {
-            "version": "3.3.1",
-            "resolved": "https://registry.npmjs.org/html-tags/-/html-tags-3.3.1.tgz",
-            "integrity": "sha512-ztqyC3kLto0e9WbNp0aeP+M3kTt+nbaIveGmUxAtZa+8iFgKLUOD4YKM5j+f3QD89bra7UeumolZHKuOXnTmeQ==",
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/html-tags/-/html-tags-5.1.0.tgz",
+            "integrity": "sha512-n6l5uca7/y5joxZ3LUePhzmBFUJ+U2YWzhMa8XUTecSeSlQiZdF5XAd/Q3/WUl0VsXgUwWi8I7CNIwdI5WN1SQ==",
             "dev": true,
+            "license": "MIT",
             "engines": {
-                "node": ">=8"
+                "node": ">=20.10"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
@@ -6953,6 +6917,7 @@
             "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.1.tgz",
             "integrity": "sha512-5Fytz/IraMjqpwfd34ke28PTVMjZjJG2MPn5t7OE4eUCUNf8BAa7b5WUS9/Qvr6mwOQS7Mk6vdsMno5he+T8Xw==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": ">= 4"
             }
@@ -6999,11 +6964,23 @@
                 "node": ">=8"
             }
         },
+        "node_modules/import-meta-resolve": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.2.0.tgz",
+            "integrity": "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/wooorm"
+            }
+        },
         "node_modules/imurmurhash": {
             "version": "0.1.4",
             "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
             "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": ">=0.8.19"
             }
@@ -7379,6 +7356,17 @@
                 "node": ">=8"
             }
         },
+        "node_modules/is-plain-object": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+            "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
         "node_modules/is-regex": {
             "version": "1.1.4",
             "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
@@ -7642,7 +7630,8 @@
             "resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.37.0.tgz",
             "integrity": "sha512-JCDrsP4Z1Sb9JwG0aJ8Eo2r7k4Ou5MwmThS/6lcIe1ICyb7UBJKGRIUUdqc2ASdE/42lgz6zFUnzAIhtXnBVrQ==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/kolorist": {
             "version": "1.8.0",
@@ -7796,10 +7785,11 @@
             }
         },
         "node_modules/mathml-tag-names": {
-            "version": "2.1.3",
-            "resolved": "https://registry.npmjs.org/mathml-tag-names/-/mathml-tag-names-2.1.3.tgz",
-            "integrity": "sha512-APMBEanjybaPzUrfqU0IMU5I0AswKMH7k8OTLs0vvV4KZpExkTkY87nR/zpbuTPj+gARop7aGUbl11pnDfW6xg==",
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/mathml-tag-names/-/mathml-tag-names-4.0.0.tgz",
+            "integrity": "sha512-aa6AU2Pcx0VP/XWnh8IGL0SYSgQHDT6Ucror2j2mXeFAlN3ahaNs8EZtG1YiticMkSLj3Gt6VPFfZogt7G5iFQ==",
             "dev": true,
+            "license": "MIT",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/wooorm"
@@ -8025,9 +8015,9 @@
             }
         },
         "node_modules/mdn-data": {
-            "version": "2.12.2",
-            "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.12.2.tgz",
-            "integrity": "sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==",
+            "version": "2.27.1",
+            "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+            "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
             "dev": true,
             "license": "CC0-1.0"
         },
@@ -8640,9 +8630,9 @@
             "license": "MIT"
         },
         "node_modules/nanoid": {
-            "version": "3.3.12",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-            "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+            "version": "3.3.16",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+            "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
             "funding": [
                 {
                     "type": "github",
@@ -9258,6 +9248,7 @@
             "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
             "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": ">=8"
             }
@@ -9328,9 +9319,9 @@
             }
         },
         "node_modules/postcss": {
-            "version": "8.5.15",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-            "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+            "version": "8.5.23",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+            "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -9347,7 +9338,7 @@
             ],
             "license": "MIT",
             "dependencies": {
-                "nanoid": "^3.3.12",
+                "nanoid": "^3.3.16",
                 "picocolors": "^1.1.1",
                 "source-map-js": "^1.2.1"
             },
@@ -9390,7 +9381,8 @@
             "resolved": "https://registry.npmjs.org/postcss-resolve-nested-selector/-/postcss-resolve-nested-selector-0.1.6.tgz",
             "integrity": "sha512-0sglIs9Wmkzbr8lQwEyIzlDOOC9bGmfVKcJTaxv3vMmd3uo4o4DerC3En0bnmgceeql9BfC8hRkp7cg0fjdVqw==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/postcss-safe-parser": {
             "version": "6.0.0",
@@ -9531,17 +9523,24 @@
             }
         },
         "node_modules/qified": {
-            "version": "0.6.0",
-            "resolved": "https://registry.npmjs.org/qified/-/qified-0.6.0.tgz",
-            "integrity": "sha512-tsSGN1x3h569ZSU1u6diwhltLyfUWDp3YbFHedapTmpBl0B3P6U3+Qptg7xu+v+1io1EwhdPyyRHYbEw0KN2FA==",
+            "version": "0.10.1",
+            "resolved": "https://registry.npmjs.org/qified/-/qified-0.10.1.tgz",
+            "integrity": "sha512-+Owyggi9IxT1ePKGafcI87ubSmxol6smwJ+RAHDQlx9+9cPwFWDiKFFCPuWhr9ignlGpZ9vDQLw67N4dcTVFEA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "hookified": "^1.14.0"
+                "hookified": "^2.1.1"
             },
             "engines": {
                 "node": ">=20"
             }
+        },
+        "node_modules/qified/node_modules/hookified": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/hookified/-/hookified-2.2.0.tgz",
+            "integrity": "sha512-p/LgFzRN5FeoD3DLS6bkUapeye6E4SI6yJs6KetENd18S+FBthqYq2amJUWpt5z0EQwwHemidjY5OqJGEKm5uA==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/qs": {
             "version": "6.13.0",
@@ -9809,15 +9808,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/resolve-from": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
-            "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
-            "dev": true,
-            "engines": {
-                "node": ">=8"
             }
         },
         "node_modules/resolve-pkg-maps": {
@@ -10256,6 +10246,7 @@
             "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
             "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": ">=8"
             }
@@ -10659,9 +10650,9 @@
             }
         },
         "node_modules/stylelint": {
-            "version": "16.26.1",
-            "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-16.26.1.tgz",
-            "integrity": "sha512-v20V59/crfc8sVTAtge0mdafI3AdnzQ2KsWe6v523L4OA1bJO02S7MO2oyXDCS6iWb9ckIPnqAFVItqSBQr7jw==",
+            "version": "17.14.1",
+            "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-17.14.1.tgz",
+            "integrity": "sha512-xVQwyiuxALUBNB2fBe0tmNemg9KqLtdj3T64mioFDar79B2cU8LIyz+3KL6LdiHs9NkeNfwxpKSaIVOY8f112g==",
             "dev": true,
             "funding": [
                 {
@@ -10675,51 +10666,47 @@
             ],
             "license": "MIT",
             "dependencies": {
-                "@csstools/css-parser-algorithms": "^3.0.5",
-                "@csstools/css-syntax-patches-for-csstree": "^1.0.19",
-                "@csstools/css-tokenizer": "^3.0.4",
-                "@csstools/media-query-list-parser": "^4.0.3",
-                "@csstools/selector-specificity": "^5.0.0",
-                "@dual-bundle/import-meta-resolve": "^4.2.1",
-                "balanced-match": "^2.0.0",
+                "@csstools/css-calc": "^3.2.1",
+                "@csstools/css-parser-algorithms": "^4.0.0",
+                "@csstools/css-syntax-patches-for-csstree": "^1.1.6",
+                "@csstools/css-tokenizer": "^4.0.0",
+                "@csstools/media-query-list-parser": "^5.0.0",
+                "@csstools/selector-resolve-nested": "^4.0.0",
+                "@csstools/selector-specificity": "^6.0.0",
                 "colord": "^2.9.3",
-                "cosmiconfig": "^9.0.0",
-                "css-functions-list": "^3.2.3",
-                "css-tree": "^3.1.0",
+                "cosmiconfig": "^9.0.2",
+                "css-functions-list": "^3.3.3",
+                "css-tree": "^3.2.1",
                 "debug": "^4.4.3",
                 "fast-glob": "^3.3.3",
                 "fastest-levenshtein": "^1.0.16",
-                "file-entry-cache": "^11.1.1",
+                "file-entry-cache": "^11.1.5",
                 "global-modules": "^2.0.0",
-                "globby": "^11.1.0",
+                "globby": "^16.2.1",
                 "globjoin": "^0.1.4",
-                "html-tags": "^3.3.1",
+                "html-tags": "^5.1.0",
                 "ignore": "^7.0.5",
-                "imurmurhash": "^0.1.4",
-                "is-plain-object": "^5.0.0",
-                "known-css-properties": "^0.37.0",
-                "mathml-tag-names": "^2.1.3",
-                "meow": "^13.2.0",
+                "import-meta-resolve": "^4.2.0",
+                "mathml-tag-names": "^4.0.0",
+                "meow": "^14.1.0",
                 "micromatch": "^4.0.8",
                 "normalize-path": "^3.0.0",
                 "picocolors": "^1.1.1",
-                "postcss": "^8.5.6",
-                "postcss-resolve-nested-selector": "^0.1.6",
+                "postcss": "^8.5.16",
                 "postcss-safe-parser": "^7.0.1",
-                "postcss-selector-parser": "^7.1.0",
+                "postcss-selector-parser": "^7.1.4",
                 "postcss-value-parser": "^4.2.0",
-                "resolve-from": "^5.0.0",
-                "string-width": "^4.2.3",
-                "supports-hyperlinks": "^3.2.0",
+                "string-width": "^8.2.1",
+                "supports-hyperlinks": "^4.5.0",
                 "svg-tags": "^1.0.0",
                 "table": "^6.9.0",
-                "write-file-atomic": "^5.0.1"
+                "write-file-atomic": "^7.0.1"
             },
             "bin": {
                 "stylelint": "bin/stylelint.mjs"
             },
             "engines": {
-                "node": ">=18.12.0"
+                "node": ">=20.19.0"
             }
         },
         "node_modules/stylelint-config-html": {
@@ -10727,6 +10714,7 @@
             "resolved": "https://registry.npmjs.org/stylelint-config-html/-/stylelint-config-html-1.1.0.tgz",
             "integrity": "sha512-IZv4IVESjKLumUGi+HWeb7skgO6/g4VMuAYrJdlqQFndgbj6WJAXPhaysvBiXefX79upBdQVumgYcdd17gCpjQ==",
             "dev": true,
+            "license": "MIT",
             "peer": true,
             "engines": {
                 "node": "^12 || >=14"
@@ -10740,9 +10728,9 @@
             }
         },
         "node_modules/stylelint-config-recommended": {
-            "version": "14.0.1",
-            "resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-14.0.1.tgz",
-            "integrity": "sha512-bLvc1WOz/14aPImu/cufKAZYfXs/A/owZfSMZ4N+16WGXLoX5lOir53M6odBxvhgmgdxCVnNySJmZKx73T93cg==",
+            "version": "18.0.0",
+            "resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-18.0.0.tgz",
+            "integrity": "sha512-mxgT2XY6YZ3HWWe3Di8umG6aBmWmHTblTgu/f10rqFXnyWxjKWwNdjSWkgkwCtxIKnqjSJzvFmPT5yabVIRxZg==",
             "dev": true,
             "funding": [
                 {
@@ -10754,30 +10742,32 @@
                     "url": "https://github.com/sponsors/stylelint"
                 }
             ],
+            "license": "MIT",
             "engines": {
-                "node": ">=18.12.0"
+                "node": ">=20.19.0"
             },
             "peerDependencies": {
-                "stylelint": "^16.1.0"
+                "stylelint": "^17.0.0"
             }
         },
         "node_modules/stylelint-config-recommended-scss": {
-            "version": "14.1.0",
-            "resolved": "https://registry.npmjs.org/stylelint-config-recommended-scss/-/stylelint-config-recommended-scss-14.1.0.tgz",
-            "integrity": "sha512-bhaMhh1u5dQqSsf6ri2GVWWQW5iUjBYgcHkh7SgDDn92ijoItC/cfO/W+fpXshgTQWhwFkP1rVcewcv4jaftRg==",
+            "version": "17.0.1",
+            "resolved": "https://registry.npmjs.org/stylelint-config-recommended-scss/-/stylelint-config-recommended-scss-17.0.1.tgz",
+            "integrity": "sha512-x5DVehzJudcwF0od3sGpgkln2PLLranFE7twwbp7dqDINCyZvwzFkMc6TLhNOvazRiVBJYATQLouJY0xPGB8WA==",
             "dev": true,
+            "license": "MIT",
             "peer": true,
             "dependencies": {
                 "postcss-scss": "^4.0.9",
-                "stylelint-config-recommended": "^14.0.1",
-                "stylelint-scss": "^6.4.0"
+                "stylelint-config-recommended": "^18.0.0",
+                "stylelint-scss": "^7.0.0"
             },
             "engines": {
-                "node": ">=18.12.0"
+                "node": ">=20"
             },
             "peerDependencies": {
                 "postcss": "^8.3.3",
-                "stylelint": "^16.6.1"
+                "stylelint": "^17.0.0"
             },
             "peerDependenciesMeta": {
                 "postcss": {
@@ -10786,10 +10776,11 @@
             }
         },
         "node_modules/stylelint-config-recommended-vue": {
-            "version": "1.5.0",
-            "resolved": "https://registry.npmjs.org/stylelint-config-recommended-vue/-/stylelint-config-recommended-vue-1.5.0.tgz",
-            "integrity": "sha512-65TAK/clUqkNtkZLcuytoxU0URQYlml+30Nhop7sRkCZ/mtWdXt7T+spPSB3KMKlb+82aEVJ4OrcstyDBdbosg==",
+            "version": "1.6.1",
+            "resolved": "https://registry.npmjs.org/stylelint-config-recommended-vue/-/stylelint-config-recommended-vue-1.6.1.tgz",
+            "integrity": "sha512-lLW7hTIMBiTfjenGuDq2kyHA6fBWd/+Df7MO4/AWOxiFeXP9clbpKgg27kHfwA3H7UNMGC7aeP3mNlZB5LMmEQ==",
             "dev": true,
+            "license": "MIT",
             "peer": true,
             "dependencies": {
                 "semver": "^7.3.5",
@@ -10808,10 +10799,11 @@
             }
         },
         "node_modules/stylelint-config-recommended-vue/node_modules/semver": {
-            "version": "7.6.2",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
-            "integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
+            "version": "7.8.5",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+            "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
             "dev": true,
+            "license": "ISC",
             "peer": true,
             "bin": {
                 "semver": "bin/semver.js"
@@ -10821,9 +10813,9 @@
             }
         },
         "node_modules/stylelint-config-standard": {
-            "version": "36.0.1",
-            "resolved": "https://registry.npmjs.org/stylelint-config-standard/-/stylelint-config-standard-36.0.1.tgz",
-            "integrity": "sha512-8aX8mTzJ6cuO8mmD5yon61CWuIM4UD8Q5aBcWKGSf6kg+EC3uhB+iOywpTK4ca6ZL7B49en8yanOFtUW0qNzyw==",
+            "version": "40.0.0",
+            "resolved": "https://registry.npmjs.org/stylelint-config-standard/-/stylelint-config-standard-40.0.0.tgz",
+            "integrity": "sha512-EznGJxOUhtWck2r6dJpbgAdPATIzvpLdK9+i5qPd4Lx70es66TkBPljSg4wN3Qnc6c4h2n+WbUrUynQ3fanjHw==",
             "dev": true,
             "funding": [
                 {
@@ -10835,47 +10827,237 @@
                     "url": "https://github.com/sponsors/stylelint"
                 }
             ],
+            "license": "MIT",
             "dependencies": {
-                "stylelint-config-recommended": "^14.0.1"
+                "stylelint-config-recommended": "^18.0.0"
             },
             "engines": {
-                "node": ">=18.12.0"
+                "node": ">=20.19.0"
             },
             "peerDependencies": {
-                "stylelint": "^16.1.0"
+                "stylelint": "^17.0.0"
             }
         },
         "node_modules/stylelint-scss": {
-            "version": "6.4.1",
-            "resolved": "https://registry.npmjs.org/stylelint-scss/-/stylelint-scss-6.4.1.tgz",
-            "integrity": "sha512-+clI2bQC2FPOt06ZwUlXZZ95IO2C5bKTP0GLN1LNQPVvISfSNcgMKv/VTwym1mK9vnqhHbOk8lO4rj4nY7L9pw==",
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/stylelint-scss/-/stylelint-scss-7.2.0.tgz",
+            "integrity": "sha512-6E79Bachv0Iz0gqRUZgdqdXCsiq26DWBWIBNHYtjTmAp3wJu6cp/I37VfW7BPntmh2puF3bY09XWl4HZGrLhzw==",
             "dev": true,
+            "license": "MIT",
             "peer": true,
             "dependencies": {
-                "known-css-properties": "^0.34.0",
+                "@csstools/css-calc": "^3.2.1",
+                "@csstools/css-parser-algorithms": "^4.0.0",
+                "@csstools/css-syntax-patches-for-csstree": "^1.1.4",
+                "@csstools/css-tokenizer": "^4.0.0",
+                "css-tree": "^3.2.1",
+                "is-plain-object": "^5.0.0",
+                "known-css-properties": "^0.37.0",
                 "postcss-media-query-parser": "^0.2.3",
-                "postcss-resolve-nested-selector": "^0.1.1",
-                "postcss-selector-parser": "^6.1.0",
+                "postcss-resolve-nested-selector": "^0.1.6",
+                "postcss-selector-parser": "^7.1.1",
                 "postcss-value-parser": "^4.2.0"
             },
             "engines": {
-                "node": ">=18.12.0"
+                "node": ">=20.19.0"
             },
             "peerDependencies": {
-                "stylelint": "^16.0.2"
+                "stylelint": "^16.8.2 || ^17.0.0"
             }
         },
-        "node_modules/stylelint-scss/node_modules/known-css-properties": {
-            "version": "0.34.0",
-            "resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.34.0.tgz",
-            "integrity": "sha512-tBECoUqNFbyAY4RrbqsBQqDFpGXAEbdD5QKr8kACx3+rnArmuuR22nKQWKazvp07N9yjTyDZaw/20UIH8tL9DQ==",
+        "node_modules/stylelint-scss/node_modules/@csstools/css-calc": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.3.0.tgz",
+            "integrity": "sha512-c5ihYsPkdG6JCkU2zTMm4+k6r7RXuGxtWYhu5DHMIiF1FHzrfmHL5so11AoFpUv/tu61xfcmT4AmKoFfMPoqdQ==",
             "dev": true,
-            "peer": true
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/csstools"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/csstools"
+                }
+            ],
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=20.19.0"
+            },
+            "peerDependencies": {
+                "@csstools/css-parser-algorithms": "^4.0.0",
+                "@csstools/css-tokenizer": "^4.0.0"
+            }
         },
-        "node_modules/stylelint/node_modules/@csstools/selector-specificity": {
+        "node_modules/stylelint-scss/node_modules/@csstools/css-parser-algorithms": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+            "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/csstools"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/csstools"
+                }
+            ],
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=20.19.0"
+            },
+            "peerDependencies": {
+                "@csstools/css-tokenizer": "^4.0.0"
+            }
+        },
+        "node_modules/stylelint-scss/node_modules/@csstools/css-tokenizer": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+            "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/csstools"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/csstools"
+                }
+            ],
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=20.19.0"
+            }
+        },
+        "node_modules/stylelint-scss/node_modules/postcss-selector-parser": {
+            "version": "7.1.4",
+            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.4.tgz",
+            "integrity": "sha512-HeP7D2wyhkR+XaK6v4W8oRF62Dsz4flyuczALJp61GckGm42u1saSSJ/0auvcBqxs3jMRFEcPK34At/0JBKdOg==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "cssesc": "^3.0.0",
+                "util-deprecate": "^1.0.2"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/stylelint-use-logical": {
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/stylelint-use-logical/-/stylelint-use-logical-2.1.3.tgz",
+            "integrity": "sha512-haPkgxKre+eSqr4IZJnHwNT/9/wICykeFZIaz7rZbe4SohTHkw7vBahMOrZJZpdny/EBVHAcPH2IBeoiUcZWWw==",
+            "dev": true,
+            "license": "CC0-1.0",
+            "engines": {
+                "node": ">=14.0.0"
+            },
+            "peerDependencies": {
+                "stylelint": ">= 11 < 18"
+            }
+        },
+        "node_modules/stylelint/node_modules/@csstools/css-calc": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.3.0.tgz",
+            "integrity": "sha512-c5ihYsPkdG6JCkU2zTMm4+k6r7RXuGxtWYhu5DHMIiF1FHzrfmHL5so11AoFpUv/tu61xfcmT4AmKoFfMPoqdQ==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/csstools"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/csstools"
+                }
+            ],
+            "license": "MIT",
+            "engines": {
+                "node": ">=20.19.0"
+            },
+            "peerDependencies": {
+                "@csstools/css-parser-algorithms": "^4.0.0",
+                "@csstools/css-tokenizer": "^4.0.0"
+            }
+        },
+        "node_modules/stylelint/node_modules/@csstools/css-parser-algorithms": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+            "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/csstools"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/csstools"
+                }
+            ],
+            "license": "MIT",
+            "engines": {
+                "node": ">=20.19.0"
+            },
+            "peerDependencies": {
+                "@csstools/css-tokenizer": "^4.0.0"
+            }
+        },
+        "node_modules/stylelint/node_modules/@csstools/css-tokenizer": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+            "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/csstools"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/csstools"
+                }
+            ],
+            "license": "MIT",
+            "engines": {
+                "node": ">=20.19.0"
+            }
+        },
+        "node_modules/stylelint/node_modules/@csstools/media-query-list-parser": {
             "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/@csstools/selector-specificity/-/selector-specificity-5.0.0.tgz",
-            "integrity": "sha512-PCqQV3c4CoVm3kdPhyeZ07VmBRdH2EpMFA/pd9OASpOEC3aXNGoqPDAZ80D0cLpMBxnmk0+yNhGsEx31hq7Gtw==",
+            "resolved": "https://registry.npmjs.org/@csstools/media-query-list-parser/-/media-query-list-parser-5.0.0.tgz",
+            "integrity": "sha512-T9lXmZOfnam3eMERPsszjY5NK0jX8RmThmmm99FZ8b7z8yMaFZWKwLWGZuTwdO3ddRY5fy13GmmEYZXB4I98Eg==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/csstools"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/csstools"
+                }
+            ],
+            "license": "MIT",
+            "engines": {
+                "node": ">=20.19.0"
+            },
+            "peerDependencies": {
+                "@csstools/css-parser-algorithms": "^4.0.0",
+                "@csstools/css-tokenizer": "^4.0.0"
+            }
+        },
+        "node_modules/stylelint/node_modules/@csstools/selector-resolve-nested": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@csstools/selector-resolve-nested/-/selector-resolve-nested-4.0.1.tgz",
+            "integrity": "sha512-j3vdQu0XwLME5qOTWxm8cnmvsf423R2YL6DbKklCHZwkDm7UdKNu6RPlw4REIJhSlKBICY3B70/7QZdicLqZgg==",
             "dev": true,
             "funding": [
                 {
@@ -10889,57 +11071,125 @@
             ],
             "license": "MIT-0",
             "engines": {
-                "node": ">=18"
+                "node": ">=20.19.0"
             },
             "peerDependencies": {
-                "postcss-selector-parser": "^7.0.0"
+                "postcss-selector-parser": "^7.1.1"
             }
         },
-        "node_modules/stylelint/node_modules/balanced-match": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-2.0.0.tgz",
-            "integrity": "sha512-1ugUSr8BHXRnK23KfuYS+gVMC3LB8QGH9W1iGtDPsNWoQbgtXSExkBu2aDR4epiGWZOjZsj6lDl/N/AqqTC3UA==",
-            "dev": true
+        "node_modules/stylelint/node_modules/@csstools/selector-specificity": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/@csstools/selector-specificity/-/selector-specificity-6.0.0.tgz",
+            "integrity": "sha512-4sSgl78OtOXEX/2d++8A83zHNTgwCJMaR24FvsYL7Uf/VS8HZk9PTwR51elTbGqMuwH3szLvvOXEaVnqn0Z3zA==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/csstools"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/csstools"
+                }
+            ],
+            "license": "MIT-0",
+            "engines": {
+                "node": ">=20.19.0"
+            },
+            "peerDependencies": {
+                "postcss-selector-parser": "^7.1.1"
+            }
+        },
+        "node_modules/stylelint/node_modules/ansi-regex": {
+            "version": "6.2.2",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+            "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+            }
         },
         "node_modules/stylelint/node_modules/file-entry-cache": {
-            "version": "11.1.2",
-            "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-11.1.2.tgz",
-            "integrity": "sha512-N2WFfK12gmrK1c1GXOqiAJ1tc5YE+R53zvQ+t5P8S5XhnmKYVB5eZEiLNZKDSmoG8wqqbF9EXYBBW/nef19log==",
+            "version": "11.1.5",
+            "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-11.1.5.tgz",
+            "integrity": "sha512-+PFTHITI08JIGhnNpGNI8T8inUpgZfk3GNEqfT9R2zZV2iFXg3CvqzSl/uEhs7TSGujYRELEANyDvS8Fj7+S7Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "flat-cache": "^6.1.20"
+                "flat-cache": "^6.1.23"
             }
         },
         "node_modules/stylelint/node_modules/flat-cache": {
-            "version": "6.1.20",
-            "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-6.1.20.tgz",
-            "integrity": "sha512-AhHYqwvN62NVLp4lObVXGVluiABTHapoB57EyegZVmazN+hhGhLTn3uZbOofoTw4DSDvVCadzzyChXhOAvy8uQ==",
+            "version": "6.1.23",
+            "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-6.1.23.tgz",
+            "integrity": "sha512-f++BY9pTk+983xK1FLzlLpmM0i0z+jHmx3QESGkURMXujQZz1k5wzwX6hjnQ8goaD0B+sYnDK1yZ6MTyZfUaqA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "cacheable": "^2.3.2",
-                "flatted": "^3.3.3",
+                "cacheable": "^2.5.0",
+                "flatted": "^3.4.2",
                 "hookified": "^1.15.0"
             }
         },
+        "node_modules/stylelint/node_modules/globby": {
+            "version": "16.2.2",
+            "resolved": "https://registry.npmjs.org/globby/-/globby-16.2.2.tgz",
+            "integrity": "sha512-NLvV9ubZ6NDsJaOpKPy3cQeJpKi9DcWiyCiFUpJPA0YihRqiE6RWaLUmgNNPr8MgPpLZjnBjSmou7uZBRJv9wA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@sindresorhus/merge-streams": "^4.0.0",
+                "fast-glob": "^3.3.3",
+                "ignore": "^7.0.5",
+                "is-path-inside": "^4.0.0",
+                "slash": "^5.1.0",
+                "unicorn-magic": "^0.4.0"
+            },
+            "engines": {
+                "node": ">=20"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/stylelint/node_modules/ignore": {
-            "version": "7.0.5",
-            "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
-            "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+            "version": "7.0.6",
+            "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.6.tgz",
+            "integrity": "sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==",
             "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 4"
             }
         },
-        "node_modules/stylelint/node_modules/is-plain-object": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
-            "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+        "node_modules/stylelint/node_modules/is-path-inside": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-4.0.0.tgz",
+            "integrity": "sha512-lJJV/5dYS+RcL8uQdBDW9c9uWFLLBNRyFhnAKXw5tVqLlKZ4RMGZKv+YQ/IA3OhD+RpbJa1LLFM1FQPGyIXvOA==",
             "dev": true,
+            "license": "MIT",
             "engines": {
-                "node": ">=0.10.0"
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/stylelint/node_modules/meow": {
+            "version": "14.1.0",
+            "resolved": "https://registry.npmjs.org/meow/-/meow-14.1.0.tgz",
+            "integrity": "sha512-EDYo6VlmtnumlcBCbh1gLJ//9jvM/ndXHfVXIFrZVr6fGcwTUyCTFNTLCKuY3ffbK8L/+3Mzqnd58RojiZqHVw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=20"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/stylelint/node_modules/postcss-safe-parser": {
@@ -10970,9 +11220,9 @@
             }
         },
         "node_modules/stylelint/node_modules/postcss-selector-parser": {
-            "version": "7.1.1",
-            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
-            "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
+            "version": "7.1.4",
+            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.4.tgz",
+            "integrity": "sha512-HeP7D2wyhkR+XaK6v4W8oRF62Dsz4flyuczALJp61GckGm42u1saSSJ/0auvcBqxs3jMRFEcPK34At/0JBKdOg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -10981,6 +11231,52 @@
             },
             "engines": {
                 "node": ">=4"
+            }
+        },
+        "node_modules/stylelint/node_modules/slash": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/slash/-/slash-5.1.0.tgz",
+            "integrity": "sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=14.16"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/stylelint/node_modules/string-width": {
+            "version": "8.2.2",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.2.tgz",
+            "integrity": "sha512-GaPUh5gfdrYzqeVNZvUfT23vYYxXzKYidUcnMtJg/3rxRV63EFZy3k6xfKlmfeJD0176lnUV/Usr3XcwSvFzpg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "get-east-asian-width": "^1.5.0",
+                "strip-ansi": "^7.1.2"
+            },
+            "engines": {
+                "node": ">=20"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/stylelint/node_modules/strip-ansi": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+            "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-regex": "^6.2.2"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/strip-ansi?sponsor=1"
             }
         },
         "node_modules/superjson": {
@@ -11011,33 +11307,46 @@
             }
         },
         "node_modules/supports-hyperlinks": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-3.2.0.tgz",
-            "integrity": "sha512-zFObLMyZeEwzAoKCyu1B91U79K2t7ApXuQfo8OuxwXLDgcKxuwM+YvcbIhm6QWqz7mHUH1TVytR1PwVVjEuMig==",
+            "version": "4.5.0",
+            "resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-4.5.0.tgz",
+            "integrity": "sha512-ZW2OvfeCXrNTbLakPUzjQG922EeGCOteFSVoek5DKStTh898wf7zgtuFlzQN8HfZCxC3Eh02yJVrRW51hADf+w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "has-flag": "^4.0.0",
-                "supports-color": "^7.0.0"
+                "has-flag": "^5.0.1",
+                "supports-color": "^10.2.2"
             },
             "engines": {
-                "node": ">=14.18"
+                "node": ">=20"
             },
             "funding": {
                 "url": "https://github.com/chalk/supports-hyperlinks?sponsor=1"
             }
         },
-        "node_modules/supports-hyperlinks/node_modules/supports-color": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-            "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+        "node_modules/supports-hyperlinks/node_modules/has-flag": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-5.0.1.tgz",
+            "integrity": "sha512-CsNUt5x9LUdx6hnk/E2SZLsDyvfqANZSUq4+D3D8RzDJ2M+HDTIkF60ibS1vHaK55vzgiZw1bEPFG9yH7l33wA==",
             "dev": true,
             "license": "MIT",
-            "dependencies": {
-                "has-flag": "^4.0.0"
-            },
             "engines": {
-                "node": ">=8"
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/supports-hyperlinks/node_modules/supports-color": {
+            "version": "10.2.2",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
+            "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/supports-color?sponsor=1"
             }
         },
         "node_modules/supports-preserve-symlinks-flag": {
@@ -11377,6 +11686,19 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/unicorn-magic": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.4.0.tgz",
+            "integrity": "sha512-wH590V9VNgYH9g3lH9wWjTrUoKsjLF6sGLjhR4sH1LWpLmCOH0Zf7PukhDA8BiS7KHe4oPNkcTHqYkj7SOGUOw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=20"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/unified": {
@@ -12710,16 +13032,16 @@
             "peer": true
         },
         "node_modules/write-file-atomic": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-5.0.1.tgz",
-            "integrity": "sha512-+QU2zd6OTD8XWIJCbffaiQeH9U73qIqafo1x6V1snCWYGJf6cVE0cDR4D8xRzcEnfI21IFrUPzPGtcPf8AC+Rw==",
+            "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-7.0.1.tgz",
+            "integrity": "sha512-OTIk8iR8/aCRWBqvxrzxR0hgxWpnYBblY1S5hDWBQfk/VFmJwzmJgQFN3WsoUKHISv2eAwe+PpbUzyL1CKTLXg==",
             "dev": true,
+            "license": "ISC",
             "dependencies": {
-                "imurmurhash": "^0.1.4",
                 "signal-exit": "^4.0.1"
             },
             "engines": {
-                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+                "node": "^20.17.0 || >=22.9.0"
             }
         },
         "node_modules/write-file-atomic/node_modules/signal-exit": {

--- a/package.json
+++ b/package.json
@@ -39,10 +39,10 @@
     "devDependencies": {
         "@nextcloud/browserslist-config": "^3.1.2",
         "@nextcloud/eslint-config": "^8.4.1",
-        "@nextcloud/stylelint-config": "^3.0.1",
+        "@nextcloud/stylelint-config": "^3.2.2",
         "@nextcloud/vite-config": "^2.5.2",
-        "stylelint": "^16.26.1",
-        "stylelint-config-standard": "^36.0.1",
+        "stylelint": "^17.9.1",
+        "stylelint-config-standard": "^40.0.0",
         "vite": "^7.3.1"
     }
 }

--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,16 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended"
+  ],
+  "packageRules": [
+    {
+      "description": "stylelint and its shared configs declare peer ranges on each other, so bumping them separately produces an unsatisfiable tree and Renovate cannot regenerate the lockfile. Always update them in a single PR.",
+      "groupName": "stylelint",
+      "matchPackageNames": [
+        "stylelint",
+        "stylelint-config-**",
+        "@nextcloud/stylelint-config"
+      ]
+    }
   ]
 }


### PR DESCRIPTION
Fixes #116

`@nextcloud/stylelint-config` changed its `stylelint` peer range mid-3.x, so `^3.0.1` now spans a breaking peer change and the lockfile can no longer be resolved from `package.json`. This bumps the three stylelint packages together and groups them in `renovate.json`.

Only the stylelint subtree was re-resolved — 30 version changes, 24 added, 8 removed, 0 downgrades, nothing outside stylelint's tree (`vue`, `vite`, `@nextcloud/vue`, `@nextcloud/axios` untouched).

Verified: `npm ci` succeeds from the new lockfile, and `npx stylelint css/*.css` (the CI command) exits 0. Note it surfaces 16 new `csstools/use-logical` **warnings** on `settings.css`, `share.css`, `template.css` — non-blocking, baseline was clean.

Once merged, #61 and #62 are redundant and can be closed; #63 should regenerate.

Assisted-by: ClaudeCode:claude-opus-5