### PR TITLE
ci: run workflows on main instead of dormant master/develop

### DIFF
--- a/.github/workflows/artifact.yml
+++ b/.github/workflows/artifact.yml
@@ -3,9 +3,9 @@ name: Artifact
 on:
   workflow_dispatch:
   push:
-    branches: [master]
+    branches: [main, 'stable*']
   pull_request:
-    branches: [master]
+    branches: [main, 'stable*']
 
 jobs:
   artifact:

--- a/.github/workflows/lint-eslint.yml
+++ b/.github/workflows/lint-eslint.yml
@@ -8,7 +8,11 @@ on:
     branches: [main, 'stable*']
 
 env:
-  NODE_VERSION: 20
+  # Must stay >= 24: @nextcloud/files@4 requires node ^24.0.0, and npm 10
+  # (bundled with node 20) cannot `npm ci` this lockfile because it tries to
+  # materialise fdir's *optional* picomatch peer. The release workflow already
+  # builds with node ^24 / npm ^11.3.
+  NODE_VERSION: 24
 
 jobs:
   lint:

--- a/.github/workflows/lint-eslint.yml
+++ b/.github/workflows/lint-eslint.yml
@@ -3,9 +3,9 @@ name: ESLint
 on:
   workflow_dispatch:
   push:
-    branches: [master, develop]
+    branches: [main, 'stable*']
   pull_request:
-    branches: [master, develop]
+    branches: [main, 'stable*']
 
 env:
   NODE_VERSION: 20

--- a/.github/workflows/lint-php.yml
+++ b/.github/workflows/lint-php.yml
@@ -3,9 +3,9 @@ name: Lint-php
 on:
   workflow_dispatch:
   push:
-    branches: [master, develop]
+    branches: [main, 'stable*']
   pull_request:
-    branches: [master, develop]
+    branches: [main, 'stable*']
 
 permissions:
   contents: read

--- a/.github/workflows/lint-phpcs.yml
+++ b/.github/workflows/lint-phpcs.yml
@@ -3,9 +3,9 @@ name: Lint-phpcs
 on:
   workflow_dispatch:
   push:
-    branches: [master, develop]
+    branches: [main, 'stable*']
   pull_request:
-    branches: [master, develop]
+    branches: [main, 'stable*']
 
 permissions:
   contents: read

--- a/src/desktop.js
+++ b/src/desktop.js
@@ -21,7 +21,7 @@
  *
  */
 
-/* global _, _oc_appswebroots, oc_current_user  */
+/* global _oc_appswebroots, oc_current_user  */
 
 /**
  * @param {object} OCA Nextcloud OCA object

--- a/src/directeditor.js
+++ b/src/directeditor.js
@@ -21,8 +21,6 @@
  *
  */
 
-/* global _ */
-
 /**
  * @param {object} OCA Nextcloud OCA object
  */

--- a/src/editor.js
+++ b/src/editor.js
@@ -21,7 +21,7 @@
  *
  */
 
-/* global _, DocsAPI, moment, oc_defaults */
+/* global DocsAPI, moment, oc_defaults */
 
 import axios from '@nextcloud/axios'
 

--- a/src/listener.js
+++ b/src/listener.js
@@ -21,7 +21,7 @@
  *
  */
 
-/* global _, OC, OCP, t */
+/* global OC, OCP, t */
 
 import { getLinkWithPicker } from '@nextcloud/vue/components/NcRichText'
 
@@ -98,47 +98,47 @@ import { getLinkWithPicker } from '@nextcloud/vue/components/NcRichText'
 	// the modal manually. The modal's built-in close button dismisses it.
 	OCA.Eurooffice.onSmartPickerRequest = async function(selectedText, source) {
 		if (this.showSmartPicker) {
-			return;
+			return
 		}
-		this.showSmartPicker = true;
+		this.showSmartPicker = true
 
 		if (source === 'contextmenu') {
-			const openAssistantForm = window.OCA?.Assistant?.openAssistantForm;
+			const openAssistantForm = window.OCA?.Assistant?.openAssistantForm
 			if (typeof openAssistantForm !== 'function') {
-				console.debug('NC Assistant app is not loaded; smart picker is unavailable');
-				this.showSmartPicker = false;
-				return;
+				console.debug('NC Assistant app is not loaded; smart picker is unavailable')
+				this.showSmartPicker = false
+				return
 			}
 			try {
 				const seedInputs = selectedText
 					? { prompt: selectedText, input: selectedText, text: selectedText }
-					: {};
+					: {}
 				await openAssistantForm({
 					appId: OCA.Eurooffice.AppName,
 					taskType: 'core:text2text',
 					inputs: seedInputs,
 					closeOnResult: false,
-				});
+				})
 			} catch (e) {
 				// Smart Picker cancelled or failed
 			}
 		} else {
 			// Toolbar button: open the Smart Picker provider selection modal
 			if (typeof getLinkWithPicker !== 'function') {
-				console.error('getLinkWithPicker is not available. Make sure @nextcloud/vue supports the Smart Picker.');
-				this.showSmartPicker = false;
-				return;
+				console.error('getLinkWithPicker is not available. Make sure @nextcloud/vue supports the Smart Picker.')
+				this.showSmartPicker = false
+				return
 			}
 			try {
-				const linkUrl = await getLinkWithPicker('eurooffice', false);
+				const linkUrl = await getLinkWithPicker('eurooffice', false)
 				if (linkUrl) {
-					OCA.Eurooffice.onInsertLink(linkUrl);
+					OCA.Eurooffice.onInsertLink(linkUrl)
 				}
 			} catch (err) {
-				console.debug('Smart Picker cancelled or failed:', err);
+				console.debug('Smart Picker cancelled or failed:', err)
 			}
 		}
-		this.showSmartPicker = false;
+		this.showSmartPicker = false
 	}
 
 	OCA.Eurooffice.onRequestMailMergeRecipients = function(recipientMimes) {
@@ -204,10 +204,10 @@ import { getLinkWithPicker } from '@nextcloud/vue/components/NcRichText'
 	OCA.Eurooffice._isDocumentReady = false
 
 	OCA.Eurooffice._doInsertLink = function(link) {
-		if (!link) return;
-		const frame = document.querySelector(OCA.Eurooffice.frameSelector);
+		if (!link) return
+		const frame = document.querySelector(OCA.Eurooffice.frameSelector)
 		if (frame && frame.contentWindow && frame.contentWindow.OCA?.Eurooffice?.docEditor) {
-			frame.contentWindow.OCA.Eurooffice.docEditor.insertLink(link);
+			frame.contentWindow.OCA.Eurooffice.docEditor.insertLink(link)
 		}
 	}
 

--- a/src/main.js
+++ b/src/main.js
@@ -23,7 +23,7 @@
 
 /* eslint-disable import/no-unresolved */
 
-/* global _, _oc_appswebroots */
+/* global _oc_appswebroots */
 
 import {
 	File,

--- a/src/share.js
+++ b/src/share.js
@@ -23,8 +23,6 @@
 
 /* eslint-disable import/no-unresolved */
 
-/* global _ */
-
 import AppDarkSvg from '../img/app-dark.svg?raw'
 import axios from '@nextcloud/axios'
 

--- a/src/template.js
+++ b/src/template.js
@@ -21,8 +21,6 @@
  *
  */
 
-/* global _ */
-
 import axios from '@nextcloud/axios'
 import { spawnDialog } from '@nextcloud/vue/functions/dialog'
 import { defineAsyncComponent } from 'vue'


### PR DESCRIPTION
## Summary

The project moved from `master` to `main` between v10 and v11 (`v10.0.0` is on `master`/`stable10`; `v11.0.0` and `v11.0.1` are on `main`), but the workflow branch filters were never updated. As a result **Artifact, ESLint, Lint-php and Lint-phpcs had not run since 2026-05-21** and never ran for a `main`-targeted PR — leaving `DCO` as the only check on every PR.

This re-points them at `main` (plus `stable*` for maintenance lines) and fixes the two things that stopped them passing once enabled.

Found while reviewing #117, whose CI verification turned out to be unverifiable for exactly this reason.

## Commits

1. **`ci: run workflows on main instead of dormant master/develop`** — branch filters
   `[master, develop]` / `[master]` → `[main, 'stable*']` in `artifact.yml`,
   `lint-eslint.yml`, `lint-php.yml`, `lint-phpcs.yml`.
2. **`ci(eslint): build on node 24 to match the release pipeline`** — `NODE_VERSION: 20` → `24`.
3. **`fix(lint): clear eslint errors blocking CI on main`** — the 25 pre-existing eslint errors.

## Why node 24 (commit 2)

With the filters fixed, ESLint failed at `npm ci`:

```
npm error `npm ci` can only install packages when your package.json and
npm-shrinkwrap.json are in sync.
npm error Missing: picomatch@4.0.5 from lock file
```

The lockfile is not corrupt. `fdir@6.5.0` declares `picomatch: ^3 || ^4` as an **optional** peer (`peerDependenciesMeta.picomatch.optional: true`). npm 10 — bundled with node 20 — tries to materialise that optional peer, resolves it to the newest match (`picomatch@4.0.5`, published recently), finds no lockfile entry and aborts. npm 11 honours the optionality and installs cleanly.

Nothing in this repo changed to cause it; it started failing when picomatch shipped 4.0.5.

Node 20 was the wrong pin regardless:

- `@nextcloud/files@4.0.0` — a direct dependency — declares `engines.node: ^24.0.0`. Node 20 violates it (the `EBADENGINE` line in the failing log).
- `appstore-build-publish.yml` already builds releases on node `^24` / npm `^11.3`, so release and lint CI were on different major toolchains.

## Why the lint cleanup (commit 3)

Two mechanical, pre-existing problems, both surfaced only because CI finally ran:

- **18 × `semi`**, all in `src/listener.js`. The shared config sets `semi: ['error', 'never']`; that one file was written with semicolons. Fixed by `eslint --fix`.
- **7 × `no-unused-vars`** — `desktop.js`, `directeditor.js`, `editor.js`, `listener.js`, `main.js`, `share.js`, `template.js` each declared `_` in a `/* global */` comment for Nextcloud's retired Underscore.js. `_(` appears **nowhere** in any of them, so the declaration is dropped (and the comment removed entirely where `_` was its only entry).

No behavioural change: 6 files are comment-only, and `listener.js` is 18 trailing-semicolon removals plus its comment — verified line by line.

## Workflow audit

Since these workflows were inherited, I checked whether each still makes sense here rather than only renaming branches:

| Workflow | Action | Rationale |
|---|---|---|
| `lint-php` | ✅ filter fixed | `php -l` clean across 51 files |
| `lint-phpcs` | ✅ filter fixed | 48 files, 0 violations against the repo's own `ruleset.xml` |
| `lint-eslint` | ✅ filter + node 24 | eslint 0 errors, stylelint 0 problems |
| `artifact` | ✅ filter fixed | full build + tarball; green in CI |
| `create-tag` | ⛔ **deliberately left on `master`** | see below |
| `release` | untouched | works — tag-triggered, ran for v11.0.1 |
| `appstore-build-publish` | untouched | correct as-is |

**`create-tag.yml` is intentionally not migrated.** It has **never run** (0 runs ever — the v11 tags were created by hand). Pointing it at `main` is not a rename but a behaviour change: it would auto-tag every non-docs push to `main`, cascading into `release.yml` → a published GitHub release. That is a release-process decision and belongs in its own PR. Either delete it as vestigial or enable it deliberately.

**`appstore-build-publish.yml` showing "skipped" is correct**, not a bug: it is guarded by `if: github.repository_owner == 'nextcloud-releases'` and only runs in the mirror. `release.yml` handles the Euro-Office side, as its inline comment explains.

The two remaining `master` references in `appstore-build-publish.yml` point at *nextcloud/server*'s branch and the `app-certificate-requests` repo — deliberately untouched.

## Verification

All 8 checks green: Artifact, ESLint, Lint-php (8.1–8.4), Lint-phpcs, DCO.

Confirmed locally against the exact CI commands before pushing, with results matching CI character-for-character (`✖ 90 problems (25 errors, 65 warnings)` before the cleanup, `0 errors` after).

## Known follow-ups (not in this PR)

- **65 `@nextcloud/no-deprecations` warnings** remain (`OC.generateUrl`, `OCP.Toast`, `OC.filePath`, `OC.linkToOCS`). Non-blocking, pre-existing. Worth a separate cleanup — and note that if `--max-warnings 0` is ever added, they become failures.
- **`artifact.yml` runs `npm install`, not `npm ci`**, so it re-resolves and silently ignores the lockfile. It stayed green through the npm-10 breakage that ESLint caught. Switching it to `npm ci` would make it a real lockfile gate.
- **No `engines` in `package.json`.** Declaring `node`/`npm` would make the release pipeline's `^24` / `^11.3` fallback explicit instead of accidental, and give Renovate a constraint for lockfile regeneration.
- **`create-tag.yml`** needs the decision described above.

Assisted-by: ClaudeCode:claude-opus-5
