### PR TITLE
fix(config): mark the document server secret as sensitive

### DIFF
--- a/lib/AppConfig.php
+++ b/lib/AppConfig.php
@@ -536,7 +536,9 @@ class AppConfig {
             $this->logger->info("Set secret key", ["app" => $this->appName]);
         }
 
-        $this->appConfig->setValueString($this->appName, $this->_jwtSecret, $secret);
+        // Sensitive, so the key is masked in `occ config:list` and the admin support report
+        // instead of being handed out in plain text.
+        $this->appConfig->setValueString($this->appName, $this->_jwtSecret, $secret, sensitive: true);
     }
 
     /**


### PR DESCRIPTION
Fixes bug https://github.com/nextcloud/server/issues/63302 "Eurooffice jwt_secret is exposed in system report"

`setDocumentServerSecret()` writes `jwt_secret` to app config with default
flags, so the value is stored without `VALUE_SENSITIVE` and `occ config:list`,
`occ config:list eurooffice` and the Support → system report all print the
document server signing key verbatim. This passes `sensitive: true`.

Server masks an app config key only if it carries `VALUE_SENSITIVE` or if it
appears in the hardcoded list in `lib/private/AppConfig.php::getSensitiveKeys()`
— which covers `onlyoffice` and not us. nextcloud/server#63302 tracks adding the
missing entry there, but setting the flag ourselves is the better fix: it works
on every server release the app supports, with nothing to wait for. Reported for
All-in-One first in nextcloud/all-in-one#8317.

`setTypedValue()` keeps the sensitive flag sticky once a key is stored with it,
so any secret written by an earlier version is upgraded the next time it is
saved. Nothing to migrate.

No unit test: the repo has no PHP test suite, only the lint workflows, and
standing one up is well outside a one-line fix. Verified by hand instead — set a
Secret Key in Administration → Euro-Office, then `occ config:list eurooffice`
shows `***REMOVED SENSITIVE VALUE***` for `jwt_secret` and the real value for
`jwt_header` next to it, and opening a document still works, so the app itself
still reads the key fine.

Assisted-by: ClaudeCode:claude-opus-5