### PR TITLE
fix(settings): repair admin panel on Nextcloud 35

### DIFF
--- a/css/settings.css
+++ b/css/settings.css
@@ -31,9 +31,53 @@
     margin-top: 16px;
 }
 
-.section-eurooffice input {
+.section-eurooffice input:not([type="checkbox"]):not([type="radio"]):not(.eurooffice-picker-mount input) {
     display: block;
     width: 250px;
+}
+
+/*
+ * Nextcloud core still ships the legacy `.checkbox` / `.radio` rules, which move
+ * the real input off-canvas (`position: absolute; inset-inline-start: -10000px`)
+ * and paint a fake control with `label::before`. That markup is deprecated and
+ * misbehaves inside the Vue-managed settings container of recent servers.
+ * Render real, in-flow controls instead so the section does not depend on
+ * core's legacy stylesheet at all.
+ */
+.section-eurooffice input[type="checkbox"].checkbox,
+.section-eurooffice input[type="radio"].radio {
+    position: static;
+    inset-inline-start: auto;
+    top: auto;
+    display: inline-block;
+    width: 16px;
+    height: 16px;
+    min-height: 16px;
+    margin: 0 8px 0 0;
+    margin-inline: 0 8px;
+    overflow: visible;
+    vertical-align: middle;
+    accent-color: var(--color-primary-element, #0082c9);
+    cursor: pointer;
+}
+
+.section-eurooffice input[type="checkbox"].checkbox:disabled,
+.section-eurooffice input[type="radio"].radio:disabled {
+    cursor: default;
+}
+
+/* Drop core's pseudo-element control, otherwise it is drawn twice. */
+.section-eurooffice input[type="checkbox"].checkbox + label::before,
+.section-eurooffice input[type="radio"].radio + label::before {
+    content: none;
+}
+
+.section-eurooffice input[type="checkbox"].checkbox + label,
+.section-eurooffice input[type="radio"].radio + label {
+    display: inline;
+    padding: 0;
+    vertical-align: middle;
+    cursor: pointer;
 }
 
 .eurooffice-hide {
@@ -58,14 +102,9 @@
     margin-left: 90px;
 }
 
-#s2id_euroofficeLimitGroups,
-#s2id_euroofficeWatermark_allGroupsList,
-#s2id_euroofficeWatermark_allTagsList,
-#s2id_euroofficeWatermark_linkTagsList {
-    margin-bottom: 16px;
-    margin-left: 18px;
-    margin-top: 6px;
-    width: 250px;
+/* Mount points for the group / system tag pickers (see src/views/ListPicker.vue) */
+.eurooffice-picker-mount {
+    max-width: 400px;
 }
 
 .eurooffice-exts {

--- a/lib/AppConfig.php
+++ b/lib/AppConfig.php
@@ -953,12 +953,28 @@ class AppConfig {
     }
 
     /**
+     * Normalize a setting value that can reach us either as a JSON boolean
+     * (admin panel, which posts application/json) or as a string ("true",
+     * "yes", "on" - occ commands, config.php, form encoded requests).
+     */
+    public static function isTrue(mixed $value): bool {
+        if (is_bool($value)) {
+            return $value;
+        }
+        if (is_string($value)) {
+            return in_array(strtolower($value), ["true", "yes", "on", "1"], true);
+        }
+        return (bool) $value;
+    }
+
+    /**
      * Save watermark settings
      */
     public function setWatermarkSettings(array $settings): void {
-        $this->logger->info("Set watermark enabled: " . $settings["enabled"], ["app" => $this->appName]);
+        $enabled = self::isTrue($settings["enabled"] ?? false);
+        $this->logger->info("Set watermark enabled: " . ($enabled ? "true" : "false"), ["app" => $this->appName]);
 
-        if ($settings["enabled"] !== "true") {
+        if (!$enabled) {
             $this->appConfig->setValueString(AppConfig::WATERMARK_APP_NAMESPACE, "watermark_enabled", "no");
             return;
         }
@@ -977,10 +993,7 @@ class AppConfig {
             "shareRead",
         ];
         foreach ($watermarkLabels as $key) {
-            if (empty($settings[$key])) {
-                $settings[$key] = [];
-            }
-            $value = $settings[$key] === "true" ? "yes" : "no";
+            $value = self::isTrue($settings[$key] ?? false) ? "yes" : "no";
             $this->appConfig->setValueString(AppConfig::WATERMARK_APP_NAMESPACE, "watermark_" . $key, $value);
         }
 

--- a/lib/Controller/SettingsController.php
+++ b/lib/Controller/SettingsController.php
@@ -233,7 +233,7 @@ class SettingsController extends Controller {
         string $protection
     ): DataResponse {
 
-        if ($watermarks["enabled"] === "true") {
+        if (AppConfig::isTrue($watermarks["enabled"] ?? false)) {
             $watermarks["text"] = trim((string) $watermarks["text"]);
             if (empty($watermarks["text"])) {
                 $watermarks["text"] = $this->trans->t("DO NOT SHARE THIS") . " {userId} {date}";

--- a/src/settings.js
+++ b/src/settings.js
@@ -21,8 +21,6 @@
  *
  */
 
-/* global _ */
-
 import { spawnDialog } from '@nextcloud/vue/functions/dialog'
 import { createApp, defineAsyncComponent } from 'vue'
 import axios from '@nextcloud/axios'
@@ -72,12 +70,37 @@ import axios from '@nextcloud/axios'
 			groupsCheckbox.checked = limitGroupsSelect.value !== ''
 		}
 
+		const ListPicker = defineAsyncComponent(() => import('./views/ListPicker.vue'))
+		const mountedPickers = new Set()
+
+		/**
+		 * Mount a group / tag picker next to its hidden value input.
+		 *
+		 * @param {string} target id of the hidden input holding the value
+		 * @param {string} type either 'groups' or 'tags'
+		 * @param {string} label accessible label for the picker
+		 */
+		const mountPicker = function(target, type, label) {
+			const container = document.getElementById(target + 'Picker')
+			if (!container || mountedPickers.has(target)) {
+				return
+			}
+			mountedPickers.add(target)
+			createApp(ListPicker, { target, type, label }).mount(container)
+		}
+
 		const groupListToggle = function() {
-			if (typeof window.$ !== 'function') return
-			if (groupsCheckbox && groupsCheckbox.checked) {
-				OC.Settings.setupGroupsSelect(window.$(limitGroupsSelect))
-			} else if (limitGroupsSelect) {
-				window.$(limitGroupsSelect).select2('destroy')
+			const checked = !!(groupsCheckbox && groupsCheckbox.checked)
+			const container = document.getElementById('euroofficeLimitGroupsPicker')
+			if (container) {
+				container.classList.toggle('eurooffice-hide', !checked)
+			}
+			if (checked) {
+				mountPicker(
+					'euroofficeLimitGroups',
+					'groups',
+					t(OCA.Eurooffice.AppName, 'Allow the following groups to access the editors'),
+				)
 			}
 		}
 
@@ -142,59 +165,28 @@ import axios from '@nextcloud/axios'
 			'linkTags',
 		]
 
+		const watermarkLabels = {
+			allGroups: 'Show watermark for users of groups',
+			allTags: 'Show watermark on tagged files',
+			linkTags: 'Show watermark on link shares with specific system tags',
+		}
+
 		const watermarkNodeBehaviour = function(watermark) {
+			const target = 'euroofficeWatermark_' + watermark + 'List'
+			const type = watermark.indexOf('Group') >= 0 ? 'groups' : 'tags'
+			const watermarkCheckbox = document.getElementById('euroofficeWatermark_' + watermark)
+
 			const watermarkListToggle = function() {
-				const watermarkCheckbox = document.getElementById('euroofficeWatermark_' + watermark)
-				if (watermarkCheckbox && watermarkCheckbox.checked) {
-					if (watermark.indexOf('Group') >= 0) {
-						if (typeof window.$ !== 'function') return
-						const listElement = document.getElementById('euroofficeWatermark_' + watermark + 'List')
-						OC.Settings.setupGroupsSelect(window.$(listElement))
-					} else {
-						if (typeof window.$ !== 'function') return
-						window.$('#euroofficeWatermark_' + watermark + 'List').select2({
-							allowClear: true,
-							closeOnSelect: false,
-							multiple: true,
-							separator: '|',
-							toggleSelect: true,
-							placeholder: t(OCA.Eurooffice.AppName, 'Select tag'),
-							query: _.debounce(function(query) {
-								query.callback({
-									results: OC.SystemTags.collection.filterByName(query.term),
-								})
-							}, 100, true),
-							initSelection(element, callback) {
-								const selection = (element.value || '').split('|').map(function(tagId) {
-									return OC.SystemTags.collection.get(tagId)
-								})
-								callback(selection)
-							},
-							formatResult(tag) {
-								return OC.SystemTags.getDescriptiveTag(tag)
-							},
-							formatSelection(tag) {
-								return tag.get('name')
-							},
-							sortResults(results) {
-								results.sort(function(a, b) {
-									return OC.Util.naturalSortCompare(a.get('name'), b.get('name'))
-								})
-								return results
-							},
-						})
-					}
-				} else {
-					if (typeof window.$ === 'function') {
-						const listElement = document.getElementById('euroofficeWatermark_' + watermark + 'List')
-						if (listElement) {
-							window.$(listElement).select2('destroy')
-						}
-					}
+				const checked = !!(watermarkCheckbox && watermarkCheckbox.checked)
+				const container = document.getElementById(target + 'Picker')
+				if (container) {
+					container.classList.toggle('eurooffice-hide', !checked)
+				}
+				if (checked) {
+					mountPicker(target, type, t(OCA.Eurooffice.AppName, watermarkLabels[watermark]))
 				}
 			}
 
-			const watermarkCheckbox = document.getElementById('euroofficeWatermark_' + watermark)
 			if (watermarkCheckbox) {
 				watermarkCheckbox.addEventListener('click', watermarkListToggle)
 				watermarkListToggle()
@@ -205,15 +197,10 @@ import axios from '@nextcloud/axios'
 			watermarkNodeBehaviour(watermarkGroup)
 		})
 
-		if (OC.SystemTags && OC.SystemTags.collection) {
-			OC.SystemTags.collection.fetch({
-				success() {
-					watermarkTagLists.forEach((watermarkTag) => {
-						watermarkNodeBehaviour(watermarkTag)
-					})
-				},
-			})
-		}
+		// NcSelectTags loads the system tags itself, no OC.SystemTags needed.
+		watermarkTagLists.forEach((watermarkTag) => {
+			watermarkNodeBehaviour(watermarkTag)
+		})
 
 		const connectionErrorEl = document.getElementById('euroofficeSettingsState')
 		const connectionError = connectionErrorEl ? connectionErrorEl.value : ''
@@ -589,18 +576,32 @@ import axios from '@nextcloud/axios'
 		const sharingBlock = document.getElementById('euroofficeEnableSharingBlock')
 		const sharingCheckbox = document.getElementById('euroofficeEnableSharing')
 
-		sameTabCheckbox.onclick = function() {
-			const isChecked = sameTabCheckbox.checked
-			sharingBlock.style.display = isChecked ? 'none' : 'block'
-			sharingCheckbox.checked = isChecked ? sharingCheckbox.checked : false
+		if (sameTabCheckbox) {
+			sameTabCheckbox.addEventListener('click', function() {
+				const isChecked = sameTabCheckbox.checked
+				if (sharingBlock) {
+					sharingBlock.style.display = isChecked ? 'none' : 'block'
+				}
+				if (sharingCheckbox) {
+					sharingCheckbox.checked = isChecked ? sharingCheckbox.checked : false
+				}
+			})
 		}
 
-		// Mount FontManager Vue component
-		const fontManagerEl = document.getElementById('eurooffice-font-manager')
-		if (fontManagerEl) {
+		// Mount FontManager Vue component.
+		// Recent servers move the whole server-rendered settings markup into a
+		// Vue-managed container (see SettingsContentWrapper.vue in the settings
+		// app), so re-resolve the mount point on the next frame and mount into
+		// the node that actually ended up in the document.
+		requestAnimationFrame(function() {
+			const fontManagerEl = document.getElementById('eurooffice-font-manager')
+			if (!fontManagerEl || fontManagerEl.dataset.euroofficeMounted === 'true') {
+				return
+			}
+			fontManagerEl.dataset.euroofficeMounted = 'true'
 			const FontManager = defineAsyncComponent(() => import('./views/FontManager.vue'))
 			createApp(FontManager).mount(fontManagerEl)
-		}
+		})
 	})
 
 })(OC)

--- a/src/settings.js
+++ b/src/settings.js
@@ -71,6 +71,9 @@ import axios from '@nextcloud/axios'
 		}
 
 		const ListPicker = defineAsyncComponent(() => import('./views/ListPicker.vue'))
+		// The toggle handlers below run on every click of their checkbox, so
+		// remember which pickers are already mounted. This guards repeated
+		// calls within one page life, not repeated execution of this bundle.
 		const mountedPickers = new Set()
 
 		/**
@@ -595,12 +598,10 @@ import axios from '@nextcloud/axios'
 		// the node that actually ended up in the document.
 		requestAnimationFrame(function() {
 			const fontManagerEl = document.getElementById('eurooffice-font-manager')
-			if (!fontManagerEl || fontManagerEl.dataset.euroofficeMounted === 'true') {
-				return
+			if (fontManagerEl) {
+				const FontManager = defineAsyncComponent(() => import('./views/FontManager.vue'))
+				createApp(FontManager).mount(fontManagerEl)
 			}
-			fontManagerEl.dataset.euroofficeMounted = 'true'
-			const FontManager = defineAsyncComponent(() => import('./views/FontManager.vue'))
-			createApp(FontManager).mount(fontManagerEl)
 		})
 	})
 

--- a/src/views/ListPicker.vue
+++ b/src/views/ListPicker.vue
@@ -1,0 +1,112 @@
+<!--
+   SPDX-FileCopyrightText: 2026 Nextcloud GmbH or an Nextcloud affiliate company and Euro-Office contributors
+   SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+<template>
+	<div class="eurooffice-picker">
+		<NcSelectTags
+			v-if="type === 'tags'"
+			:input-label="label"
+			:limit="null"
+			:model-value="selection"
+			@update:model-value="update" />
+		<NcSettingsSelectGroup
+			v-else
+			:label="label"
+			:model-value="selection"
+			@update:model-value="update" />
+	</div>
+</template>
+
+<script>
+import NcSelectTags from '@nextcloud/vue/components/NcSelectTags'
+import NcSettingsSelectGroup from '@nextcloud/vue/components/NcSettingsSelectGroup'
+
+/**
+ * Group / system tag picker for the admin settings.
+ *
+ * The server-rendered settings page keeps a hidden input per list holding a
+ * "|"-separated value. This component reads that input for its initial state
+ * and writes back to it on every change, so the existing save handlers in
+ * settings.js keep working unchanged.
+ */
+export default {
+	name: 'ListPicker',
+
+	components: {
+		NcSelectTags,
+		NcSettingsSelectGroup,
+	},
+
+	props: {
+		/**
+		 * id of the hidden input holding the "|"-separated value
+		 */
+		target: {
+			type: String,
+			required: true,
+		},
+
+		/**
+		 * Accessible label for the picker
+		 */
+		label: {
+			type: String,
+			required: true,
+		},
+
+		/**
+		 * Either 'groups' (provisioning API) or 'tags' (system tags)
+		 */
+		type: {
+			type: String,
+			default: 'groups',
+			validator: (type) => ['groups', 'tags'].includes(type),
+		},
+	},
+
+	data() {
+		return {
+			selection: [],
+		}
+	},
+
+	computed: {
+		input() {
+			return document.getElementById(this.target)
+		},
+	},
+
+	created() {
+		const raw = this.input ? this.input.value : ''
+		const values = raw ? raw.split('|').filter((entry) => entry !== '') : []
+
+		// System tag ids are integers, group ids are strings.
+		this.selection = this.type === 'tags'
+			? values.map(Number).filter((id) => Number.isInteger(id))
+			: values
+	},
+
+	methods: {
+		/**
+		 * Persist the selection back into the hidden input.
+		 *
+		 * @param {Array} value ids of the selected groups or tags
+		 */
+		update(value) {
+			this.selection = value
+			if (this.input) {
+				this.input.value = value.join('|')
+			}
+		},
+	},
+}
+</script>
+
+<style scoped>
+.eurooffice-picker {
+	max-width: 400px;
+	margin-block: 6px 16px;
+	margin-inline-start: 18px;
+}
+</style>

--- a/templates/settings.php
+++ b/templates/settings.php
@@ -27,10 +27,6 @@
     style("eurooffice", "template");
     \OCP\Util::addScript("eurooffice", "eurooffice-settings", 'core');
     \OCP\Util::addScript("eurooffice", "eurooffice-template", 'core');
-
-if ($_["tagsEnabled"]) {
-    \OCP\Util::addScript("core", "dist/systemtags");
-}
 ?>
 <div class="section section-eurooffice section-eurooffice-addr">
 
@@ -109,7 +105,8 @@ if ($_["tagsEnabled"]) {
         <input type="checkbox" class="checkbox" id="euroofficeGroups"
             <?php if (count($_["limitGroups"]) > 0) { ?>checked="checked"<?php } ?> />
         <label for="euroofficeGroups"><?php p($l->t("Allow the following groups to access the editors")) ?></label>
-        <input type="hidden" id="euroofficeLimitGroups" value="<?php p(implode("|", $_["limitGroups"])) ?>" style="display: block" />
+        <input type="hidden" id="euroofficeLimitGroups" value="<?php p(implode("|", $_["limitGroups"])) ?>" />
+        <div id="euroofficeLimitGroupsPicker" class="eurooffice-picker-mount eurooffice-hide"></div>
     </p>
 
     <p>
@@ -378,7 +375,8 @@ if ($_["tagsEnabled"]) {
             <input type="checkbox" class="checkbox" id="euroofficeWatermark_allTags"
                 <?php if ($_["watermark"]["allTags"]) { ?>checked="checked"<?php } ?> />
             <label for="euroofficeWatermark_allTags"><?php p($l->t("Show watermark on tagged files")) ?></label>
-            <input type="hidden" id="euroofficeWatermark_allTagsList" value="<?php p(implode("|", $_["watermark"]["allTagsList"])) ?>" style="display: block" />
+            <input type="hidden" id="euroofficeWatermark_allTagsList" value="<?php p(implode("|", $_["watermark"]["allTagsList"])) ?>" />
+            <div id="euroofficeWatermark_allTagsListPicker" class="eurooffice-picker-mount eurooffice-hide"></div>
         </p>
         <?php } ?>
 
@@ -386,7 +384,8 @@ if ($_["tagsEnabled"]) {
             <input type="checkbox" class="checkbox" id="euroofficeWatermark_allGroups"
                 <?php if ($_["watermark"]["allGroups"]) { ?>checked="checked"<?php } ?> />
             <label for="euroofficeWatermark_allGroups"><?php p($l->t("Show watermark for users of groups")) ?></label>
-            <input type="hidden" id="euroofficeWatermark_allGroupsList" value="<?php p(implode("|", $_["watermark"]["allGroupsList"])) ?>" style="display: block" />
+            <input type="hidden" id="euroofficeWatermark_allGroupsList" value="<?php p(implode("|", $_["watermark"]["allGroupsList"])) ?>" />
+            <div id="euroofficeWatermark_allGroupsListPicker" class="eurooffice-picker-mount eurooffice-hide"></div>
         </p>
 
         <p>
@@ -427,7 +426,8 @@ if ($_["tagsEnabled"]) {
                 <input type="checkbox" class="checkbox" id="euroofficeWatermark_linkTags"
                     <?php if ($_["watermark"]["linkTags"]) { ?>checked="checked"<?php } ?> />
                 <label for="euroofficeWatermark_linkTags"><?php p($l->t("Show watermark on link shares with specific system tags")) ?></label>
-                <input type="hidden" id="euroofficeWatermark_linkTagsList" value="<?php p(implode("|", $_["watermark"]["linkTagsList"])) ?>" style="display: block" />
+                <input type="hidden" id="euroofficeWatermark_linkTagsList" value="<?php p(implode("|", $_["watermark"]["linkTagsList"])) ?>" />
+                <div id="euroofficeWatermark_linkTagsListPicker" class="eurooffice-picker-mount eurooffice-hide"></div>
             </p>
             <?php } ?>
         </div>


### PR DESCRIPTION
Clicking any option in the admin panel (a format checkbox, "Enable live-viewing mode", "Enable watermarking", "Enable plugins"..) blanks the settings page on (at least) NC 35. Fixing that surfaced a second, older bug: watermark settings never persisted.

1. **fix(settings): repair admin panel on Nextcloud 35**
The template still uses the deprecated class="checkbox" / class="radio" markup, where core CSS moves the real input off-canvas (inset-inline-start: -10000px) and paints a fake control via label::before. NC 35 no longer renders app settings in place: SettingsContentWrapper.vue replaceChildren()-moves the markup into a Vue-managed container inside NcAppContent, which the off-canvas inputs do not survive. Format checkboxes have no app JS bound at all, confirming the markup is the trigger.
    - render real, in-flow checkboxes/radios scoped to .section-eurooffice
    - stop the generic input { width: 250px } rule applying to checkboxes
    - guard the unprotected sameTab handler, which aborted the rest of init
    - replace the select2 group/tag pickers with NcSettingsSelectGroup / NcSelectTags via a new ListPicker.vue, keeping the hidden inputs as the wire format (fixes #135, #140)
    - drop the resulting jQuery, underscore, OC.SystemTags and core/dist/systemtags dependencies

2. **fix(settings): accept JSON booleans when saving watermark settings**
setWatermarkSettings() compared enabled against the string "true", so every save stored watermark_enabled = "no" and returned early, discarding text, flags and lists. Regressed in 51e2d6a, which switched the admin panel from form-encoded $.ajax to JSON via axios; getFormats() was adapted at the time, the watermark path was not. Added AppConfig::isTrue() and routed all three call sites through it.

Follow-up: the checkbox CSS is still a stopgap: it wins on specificity against legacy core styles slated for removal. Those controls should move to NcCheckboxRadioSwitch / NcSettingsSection next.

Assisted-by: Claude Code:Opus 5