### PR TITLE
fix(callback): don't silently overwrite files on a corrupted force-save

### DIFF
--- a/lib/Controller/CallbackController.php
+++ b/lib/Controller/CallbackController.php
@@ -395,6 +395,7 @@ class CallbackController extends Controller {
         $this->setupManager->tearDown();
 
         $isForcesave = $status === self::TRACKERSTATUS_FORCESAVE || $status === self::TRACKERSTATUS_CORRUPTEDFORCESAVE;
+        $isCorrupted = $status === self::TRACKERSTATUS_CORRUPTED || $status === self::TRACKERSTATUS_CORRUPTEDFORCESAVE;
 
         $callbackUserId = $hashData->userId;
 
@@ -499,17 +500,26 @@ class CallbackController extends Controller {
                         $this->keyManager->lock($fileId, $isForcesave);
                     }
 
-                    $this->logger->debug("Track put content " . $file->getPath());
+                    if ($isCorrupted) {
+                        // DocumentServer reported the conversion as corrupted: $newData is not a
+                        // trustworthy copy of the document (empty/unconverted template, not the
+                        // user's edit). Do not overwrite the real file with it - leave the previous
+                        // content in place and tell the user their edit did not save.
+                        $this->logger->error("Track: $fileId status $status - conversion reported corrupted, not saving");
+                        $this->eventDispatcher->dispatchTyped(new DocumentUnsavedEvent($userId, $fileId, $file->getName()));
+                    } else {
+                        $this->logger->debug("Track put content " . $file->getPath());
 
-                    $retryOperation = function () use ($file, $newData): void {
-                        $this->retryOperation(fn() => $file->putContent($newData));
-                    };
+                        $retryOperation = function () use ($file, $newData): void {
+                            $this->retryOperation(fn() => $file->putContent($newData));
+                        };
 
-                    try {
-                        $lockContext = new LockContext($file, ILock::TYPE_APP, $this->appName);
-                        $this->lockManager->runInScope($lockContext, $retryOperation);
-                    } catch (NoLockProviderException $e) {
-                        $retryOperation();
+                        try {
+                            $lockContext = new LockContext($file, ILock::TYPE_APP, $this->appName);
+                            $this->lockManager->runInScope($lockContext, $retryOperation);
+                        } catch (NoLockProviderException $e) {
+                            $retryOperation();
+                        }
                     }
 
                     if (!$isForcesave) {
@@ -525,7 +535,8 @@ class CallbackController extends Controller {
                         $this->keyManager->setForcesave($fileId, $isForcesave);
                     }
 
-                    if (!$isForcesave
+                    if (!$isCorrupted
+                        && !$isForcesave
                         && !$prevIsForcesave
                         && $this->versionManager instanceof IVersionManager
                         && $this->appConfig->getVersionHistory()) {
@@ -541,7 +552,7 @@ class CallbackController extends Controller {
                         FileVersions::saveHistory($file->getFileInfo(), $history, $changes, $prevVersion);
                     }
 
-                    if (!empty($user) && $this->appConfig->getVersionHistory()) {
+                    if (!$isCorrupted && !empty($user) && $this->appConfig->getVersionHistory()) {
                         FileVersions::saveAuthor($file->getFileInfo(), $user);
                     }
 

--- a/lib/Controller/CallbackController.php
+++ b/lib/Controller/CallbackController.php
@@ -83,6 +83,14 @@ class CallbackController extends Controller {
     private const TRACKERSTATUS_FORCESAVE = 6;
     private const TRACKERSTATUS_CORRUPTEDFORCESAVE = 7;
 
+    /**
+     * DocumentServer's c_oAscServerCommandErrors.UnknownError - returning this instead of
+     * NoError (0) tells DocumentServer the save did not actually land, which activates its
+     * own "forgotten files" backup and its live updateVersion broadcast to open clients.
+     * There is no dedicated "corrupted" code in that enum.
+     */
+    private const CALLBACK_ERROR_UNKNOWN = 3;
+
     public function __construct(
         string $appName,
         IRequest $request,
@@ -507,6 +515,9 @@ class CallbackController extends Controller {
                         // content in place and tell the user their edit did not save.
                         $this->logger->error("Track: $fileId status $status - conversion reported corrupted, not saving");
                         $this->eventDispatcher->dispatchTyped(new DocumentUnsavedEvent($userId, $fileId, $file->getName()));
+                        // Tell DocumentServer this did not actually save, instead of the default
+                        // "$result = 0" below - see CALLBACK_ERROR_UNKNOWN.
+                        $result = self::CALLBACK_ERROR_UNKNOWN;
                     } else {
                         $this->logger->debug("Track put content " . $file->getPath());
 
@@ -556,7 +567,9 @@ class CallbackController extends Controller {
                         FileVersions::saveAuthor($file->getFileInfo(), $user);
                     }
 
-                    $result = 0;
+                    if (!$isCorrupted) {
+                        $result = 0;
+                    }
                 } catch (\Exception $e) {
                     $this->logger->error("Track: $fileId status $status error", ["exception" => $e]);
                     // if ($status === self::TRACKERSTATUS_MUSTSAVE) {

--- a/lib/Controller/CallbackController.php
+++ b/lib/Controller/CallbackController.php
@@ -502,6 +502,11 @@ class CallbackController extends Controller {
                     if (RemoteInstance::isRemoteFile($file)) {
                         $isLock = RemoteInstance::lockRemoteKey($file, $isForcesave, false);
                         if ($isForcesave && !$isLock) {
+                            if ($isCorrupted) {
+                                $this->logger->error("Track: $fileId status $status - conversion reported corrupted, not saving (remote lock unavailable)");
+                                $this->eventDispatcher->dispatchTyped(new DocumentUnsavedEvent($userId, $fileId, $file->getName()));
+                                $result = self::CALLBACK_ERROR_UNKNOWN;
+                            }
                             break;
                         }
                     } else {
@@ -514,7 +519,6 @@ class CallbackController extends Controller {
                         // user's edit). Do not overwrite the real file with it - leave the previous
                         // content in place and tell the user their edit did not save.
                         $this->logger->error("Track: $fileId status $status - conversion reported corrupted, not saving");
-                        $this->eventDispatcher->dispatchTyped(new DocumentUnsavedEvent($userId, $fileId, $file->getName()));
                         // Tell DocumentServer this did not actually save, instead of the default
                         // "$result = 0" below - see CALLBACK_ERROR_UNKNOWN.
                         $result = self::CALLBACK_ERROR_UNKNOWN;
@@ -567,7 +571,16 @@ class CallbackController extends Controller {
                         FileVersions::saveAuthor($file->getFileInfo(), $user);
                     }
 
-                    if (!$isCorrupted) {
+                    if ($isCorrupted) {
+                        // Dispatched last, after lock/forcesave bookkeeping above has already run -
+                        // a failure here (e.g. notification backend trouble) must not skip releasing
+                        // the lock or leave forcesave state stuck.
+                        try {
+                            $this->eventDispatcher->dispatchTyped(new DocumentUnsavedEvent($userId, $fileId, $file->getName()));
+                        } catch (\Exception $e) {
+                            $this->logger->error("Track: $fileId failed to dispatch DocumentUnsavedEvent", ["exception" => $e]);
+                        }
+                    } else {
                         $result = 0;
                     }
                 } catch (\Exception $e) {

--- a/lib/Controller/CallbackController.php
+++ b/lib/Controller/CallbackController.php
@@ -553,7 +553,7 @@ class CallbackController extends Controller {
                         }
                     } else {
                         $this->keyManager->lock($fileId, false);
-                        $this->keyManager->setForcesave($fileId, $isForcesave);
+                        $this->keyManager->setForcesave($fileId, $isForcesave && !$isCorrupted);
                     }
 
                     if (!$isCorrupted

--- a/lib/Controller/CallbackController.php
+++ b/lib/Controller/CallbackController.php
@@ -481,21 +481,27 @@ class CallbackController extends Controller {
                     $prevVersion = $file->getFileInfo()->getMtime();
                     $fileName = $file->getName();
                     $curExt = strtolower(pathinfo((string) $fileName, PATHINFO_EXTENSION));
-                    $downloadExt = $filetype;
+                    if (!$isCorrupted) {
+                        // Neither the extension conversion nor the download is needed (or
+                        // trustworthy) for a corrupted conversion - and a corrupted conversion is
+                        // exactly the case where DocumentServer's signed URL is most likely to
+                        // fail here, which would otherwise skip the corrupted-handling below.
+                        $downloadExt = $filetype;
 
-                    if ($downloadExt !== $curExt) {
-                        $key = DocumentService::generateRevisionId($fileId . $url);
+                        if ($downloadExt !== $curExt) {
+                            $key = DocumentService::generateRevisionId($fileId . $url);
 
-                        try {
-                            $this->logger->debug("Converted from $downloadExt to $curExt");
-                            $url = $this->documentService->getConvertedUri($url, $downloadExt, $curExt, $key);
-                        } catch (\Exception $e) {
-                            $this->logger->error("Converted on save error", ["exception" => $e]);
-                            return new JSONResponse(["message" => $e->getMessage()], Http::STATUS_INTERNAL_SERVER_ERROR);
+                            try {
+                                $this->logger->debug("Converted from $downloadExt to $curExt");
+                                $url = $this->documentService->getConvertedUri($url, $downloadExt, $curExt, $key);
+                            } catch (\Exception $e) {
+                                $this->logger->error("Converted on save error", ["exception" => $e]);
+                                return new JSONResponse(["message" => $e->getMessage()], Http::STATUS_INTERNAL_SERVER_ERROR);
+                            }
                         }
-                    }
 
-                    $newData = $this->documentService->request($url);
+                        $newData = $this->documentService->request($url);
+                    }
 
                     $prevIsForcesave = $this->keyManager->wasForcesave($fileId);
 
@@ -580,9 +586,24 @@ class CallbackController extends Controller {
                     }
                 } catch (\Exception $e) {
                     $this->logger->error("Track: $fileId status $status error", ["exception" => $e]);
-                    // if ($status === self::TRACKERSTATUS_MUSTSAVE) {
-                    //     $this->eventDispatcher->dispatchTyped(new DocumentUnsavedEvent($userId, $fileId, $file->getName()));
-                    // }
+                    // A throw between the $isCorrupted guard above and notifyUnsaved() (DB/remote
+                    // lock calls) would otherwise leave the user unnotified and $result at its
+                    // accidental default of 1 instead of the intentional error code.
+                    if ($isCorrupted) {
+                        $result = self::CALLBACK_ERROR_UNKNOWN;
+                        $this->notifyUnsaved($userId, $fileId, $file->getName());
+
+                        if (!RemoteInstance::isRemoteFile($file)) {
+                            // Best-effort: the lock acquired above (line ~519) may not have been
+                            // released yet when the throw happened - don't leave the key-lock row
+                            // stuck at lock=1, which KeyManager::delete() otherwise never cleans up.
+                            try {
+                                $this->keyManager->lock($fileId, false);
+                            } catch (\Exception $lockException) {
+                                $this->logger->error("Track: $fileId failed to release key lock after error", ["exception" => $lockException]);
+                            }
+                        }
+                    }
                 }
                 break;
 

--- a/lib/Controller/CallbackController.php
+++ b/lib/Controller/CallbackController.php
@@ -504,8 +504,8 @@ class CallbackController extends Controller {
                         if ($isForcesave && !$isLock) {
                             if ($isCorrupted) {
                                 $this->logger->error("Track: $fileId status $status - conversion reported corrupted, not saving (remote lock unavailable)");
-                                $this->eventDispatcher->dispatchTyped(new DocumentUnsavedEvent($userId, $fileId, $file->getName()));
                                 $result = self::CALLBACK_ERROR_UNKNOWN;
+                                $this->notifyUnsaved($userId, $fileId, $file->getName());
                             }
                             break;
                         }
@@ -573,13 +573,8 @@ class CallbackController extends Controller {
 
                     if ($isCorrupted) {
                         // Dispatched last, after lock/forcesave bookkeeping above has already run -
-                        // a failure here (e.g. notification backend trouble) must not skip releasing
-                        // the lock or leave forcesave state stuck.
-                        try {
-                            $this->eventDispatcher->dispatchTyped(new DocumentUnsavedEvent($userId, $fileId, $file->getName()));
-                        } catch (\Exception $e) {
-                            $this->logger->error("Track: $fileId failed to dispatch DocumentUnsavedEvent", ["exception" => $e]);
-                        }
+                        // see notifyUnsaved().
+                        $this->notifyUnsaved($userId, $fileId, $file->getName());
                     } else {
                         $result = 0;
                     }
@@ -776,6 +771,22 @@ class CallbackController extends Controller {
         }
 
         return $userId;
+    }
+
+    /**
+     * Tell the user their edit did not save. Dispatch is defensive: a notification-backend
+     * failure must not escape track() and skip the lock/forcesave bookkeeping around it.
+     */
+    private function notifyUnsaved(?string $userId, int $fileId, string $fileName): void {
+        if (empty($userId)) {
+            return;
+        }
+
+        try {
+            $this->eventDispatcher->dispatchTyped(new DocumentUnsavedEvent($userId, $fileId, $fileName));
+        } catch (\Throwable $e) {
+            $this->logger->error("Track: $fileId failed to dispatch DocumentUnsavedEvent", ["exception" => $e]);
+        }
     }
 
     /**


### PR DESCRIPTION
Fixes #160.

## Summary

When DocumentServer reports a corrupted conversion during a force-save (`TRACKERSTATUS_CORRUPTED` / `TRACKERSTATUS_CORRUPTEDFORCESAVE`), `CallbackController::track()` handled it in the same switch case as a genuine save and unconditionally called `$file->putContent($newData)` - silently overwriting the real file with the corrupted/empty conversion output while reporting success back to both the user and DocumentServer. Root cause and full reproduction are in #160.

## What this does

- **Don't overwrite the file on a corrupted conversion.** Skips `putContent()` and the version-history bookkeeping for `Corrupted`/`CorruptedForceSave`, leaving the previous content in place. Worst case is now "this edit didn't save," not "this edit silently destroyed the previous content."
- **Tell the user.** Dispatches the existing (previously unwired) `DocumentUnsavedEvent`, which surfaces a persistent Nextcloud notification: *"Filename.docx could not be saved. Please open the file again."* with a link back to the file.
- **Tell DocumentServer the truth.** Previously returned `{"error": 0}` unconditionally, even on the corrupted path. Now returns a real error code, which activates DocumentServer's own existing (and previously unused, for this failure class) recovery machinery: its "forgotten files" backup and its live `updateVersion` broadcast to any still-connected client.
- Closes two gaps a review pass found in the first draft: the `RemoteInstance` early-return on lock contention bypassed the new handling entirely (now handled explicitly); and the event dispatch ran before lock/forcesave bookkeeping, so an exception from the notification path could leave a lock stuck (moved to run last, wrapped defensively).

## Verification

No test harness exists for `CallbackController` in this repo (verified before writing this), so this was verified manually against the real stack rather than left unverified:

- Real Nextcloud instance, `eurooffice` connector pointed at a DocumentServer build with a confirmed conversion-crash bug (astral-plane Unicode keys crashing the no-ICU V8 in `x2t`, independently confirmed via `x2t -create-js-cache` exit code).
- Files app -> New document -> typed distinctive content -> `Ctrl+S` -> navigated away to force the real session-close callback (per #160, `Ctrl+S` alone doesn't trigger it).
- **Before this fix**: file overwritten with the empty template, content lost, no trace in Nextcloud's log.
- **After this fix**: file content downloaded via WebDAV and confirmed unchanged; `nextcloud.log` shows `Track: <fileId> status 3 - conversion reported corrupted, not saving`; DocumentServer's own `docservice` log shows `sendServerRequest returned an error: data = {"error":3}` immediately followed by `storeForgotten`, and the forgotten-file backup was confirmed created on disk.
- **Negative control**: same flow against a working DocumentServer build - content saves correctly, no error path taken, confirming no regression to normal saves.
- Re-ran the full verification again after the review-driven fixups (RemoteInstance / dispatch ordering) - same result, no regression.

The one thing I could not verify: actual delivery of the Nextcloud notification end-to-end, because this dev environment is missing the `notifications` app entirely (not a code issue - confirmed via `occ app:list` and tracing `lib/private/Notification/Manager.php`, which no-ops silently when no `IApp` is registered). Any real Nextcloud install ships that app by default.

## Out of scope (tracked separately)

- `Euro-Office/server#42` - the same class of silent-loss bug exists in DocumentServer's WOPI push path (`canvasservice.js`), and is structurally unfixable from the host/connector side - it needs a fix in DocumentServer itself.
- `Euro-Office/document-server-integration#16` - unrelated bug found during verification (`/wopi-new` hangs indefinitely on a missing param).
- A regression test for this fix belongs in this repo but needs a test harness stood up first (none exists today) - scoping that as separate work rather than bundling it here.
