### PR TITLE
fix: "Save as picture" feature (XLSX) not working

### DIFF
--- a/lib/Controller/EditorController.php
+++ b/lib/Controller/EditorController.php
@@ -1367,6 +1367,7 @@ class EditorController extends Controller {
         } else {
             $csp->addAllowedFrameDomain("'self'");
         }
+        $csp->addAllowedFrameDomain("data:");
         $response->setContentSecurityPolicy($csp);
 
         return $response;

--- a/lib/DirectEditor.php
+++ b/lib/DirectEditor.php
@@ -185,6 +185,7 @@ class DirectEditor implements IEditor {
             } else {
                 $csp->addAllowedFrameDomain("'self'");
             }
+            $csp->addAllowedFrameDomain("data:");
             $response->setContentSecurityPolicy($csp);
 
             return $response;

--- a/lib/Listeners/ContentSecurityPolicyListener.php
+++ b/lib/Listeners/ContentSecurityPolicyListener.php
@@ -50,6 +50,7 @@ class ContentSecurityPolicyListener implements IEventListener {
 
         $policy = new ContentSecurityPolicy();
         $policy->addAllowedFrameDomain("'self'");
+        $policy->addAllowedFrameDomain("data:");
 
         $event->addPolicy($policy);
     }


### PR DESCRIPTION
Saving a chart as an image renders a data:image/png;base64 URI in an iframe, which the CSP frame-src directive currently blocks as "data:" isn't implicitly covered by an origin allowlist.

This results in a javascript console error "Content-Security-Policy: The page’s settings blocked the loading of a resource (frame-src) at data:image/png;base64,iVBORw0KGgoAAAANSU… because it violates the following directive: “frame-src 'self' https://eurooffice.example.com”